### PR TITLE
Remove convenience initializers

### DIFF
--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -18,19 +18,9 @@ public final class Deferred<T> {
     private var protected: LockProtected<Protected>
     private let defaultQueue: dispatch_queue_t
 
-    private init(value: T?, queue: dispatch_queue_t) {
+    init(value: T? = nil, defaultQueue: dispatch_queue_t = DeferredDefaultQueue) {
         protected = LockProtected(item: (value, []))
-        self.defaultQueue = queue
-    }
-
-    // Initialize an unfilled Deferred
-    public convenience init(defaultQueue: dispatch_queue_t = DeferredDefaultQueue) {
-        self.init(value: nil, queue: defaultQueue)
-    }
-
-    // Initialize a filled Deferred with the given value
-    public convenience init(value: T, defaultQueue: dispatch_queue_t = DeferredDefaultQueue) {
-        self.init(value: value, queue: defaultQueue)
+        self.defaultQueue = defaultQueue
     }
 
     // Check whether or not the receiver is filled


### PR DESCRIPTION
Swift wouldn't let me override with these convenience initializers. It required that I override the private one. Then when I overrode it, it would get confused with the convenience ones. I have no idea if this is a Swift bug or yours, but it seems easier to just have one initializer with default arguments anyway. Code completion will suck, but its less code to manage.