### PR TITLE
Make non-final so Deferred can be extended

### DIFF
--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -11,7 +11,7 @@ import Foundation
 // TODO: Replace this with a class var
 private var DeferredDefaultQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
 
-public final class Deferred<T> {
+public class Deferred<T> {
     typealias UponBlock = (dispatch_queue_t, T -> ())
     private typealias Protected = (protectedValue: T?, uponBlocks: [UponBlock])
 


### PR DESCRIPTION
We have some db operations that return Deferreds. I wanted to make them cancellable, so I really wanted to return a Deferred with a cancel method that could call sqlite3_interrupt() when called. Unfortunately, Deferred is final, so you can't override it. I'm guessing you really want that, but wanted to forward the changes in case you wanted them.