### PR TITLE
LockProtected improvements

### DIFF
--- a/Deferred/ReadWriteLock.swift
+++ b/Deferred/ReadWriteLock.swift
@@ -154,3 +154,30 @@ public final class CASSpinLock: ReadWriteLock {
         return result
     }
 }
+
+public final class PThreadReadWriteLock: ReadWriteLock {
+    private var lock: UnsafeMutablePointer<pthread_rwlock_t>
+
+    public init() {
+        lock = UnsafeMutablePointer.alloc(1)
+        let status = pthread_rwlock_init(lock, nil)
+        assert(status == 0)
+    }
+
+    public func withReadLock<T>(@noescape body: () -> T) -> T {
+        let result: T
+        pthread_rwlock_rdlock(lock)
+        result = body()
+        pthread_rwlock_unlock(lock)
+        return result
+    }
+
+    public func withWriteLock<T>(@noescape body: () -> T) -> T {
+        let result: T
+        pthread_rwlock_wrlock(lock)
+        result = body()
+        pthread_rwlock_unlock(lock)
+        return result
+    }
+
+}

--- a/Deferred/ReadWriteLock.swift
+++ b/Deferred/ReadWriteLock.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol ReadWriteLock: class {
+public protocol ReadWriteLock {
     func withReadLock<T>(block: () -> T) -> T
     func withWriteLock<T>(block: () -> T) -> T
 }

--- a/Deferred/ReadWriteLock.swift
+++ b/Deferred/ReadWriteLock.swift
@@ -36,7 +36,7 @@ public struct DispatchLock: ReadWriteLock {
 }
 
 public final class SpinLock: ReadWriteLock {
-    private var lock: UnsafeMutablePointer<Int32>
+    private var lock: UnsafeMutablePointer<OSSpinLock>
 
     public init() {
         lock = UnsafeMutablePointer.alloc(1)

--- a/Deferred/ReadWriteLock.swift
+++ b/Deferred/ReadWriteLock.swift
@@ -164,6 +164,12 @@ public final class PThreadReadWriteLock: ReadWriteLock {
         assert(status == 0)
     }
 
+    deinit {
+        let status = pthread_rwlock_destroy(lock)
+        assert(status == 0)
+        lock.dealloc(1)
+    }
+
     public func withReadLock<T>(@noescape body: () -> T) -> T {
         let result: T
         pthread_rwlock_rdlock(lock)

--- a/DeferredTests/ReadWriteLockTests.swift
+++ b/DeferredTests/ReadWriteLockTests.swift
@@ -44,7 +44,7 @@ class PerfTestThread: NSThread {
 }
 
 class ReadWriteLockTests: XCTestCase {
-    var gcdLock: GCDReadWriteLock!
+    var gcdLock: DispatchLock!
     var spinLock: SpinLock!
     var casSpinLock: CASSpinLock!
     var queue: dispatch_queue_t!
@@ -52,7 +52,7 @@ class ReadWriteLockTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        gcdLock = GCDReadWriteLock()
+        gcdLock = DispatchLock()
         spinLock = SpinLock()
         casSpinLock = CASSpinLock()
 
@@ -71,7 +71,7 @@ class ReadWriteLockTests: XCTestCase {
 
     func testMultipleConcurrentReaders() {
         // do not test spinLock, as it does not allow concurrent reading
-        let locks: [ReadWriteLock] = [gcdLock, casSpinLock]
+        let locks: [ReadWriteLock] = [casSpinLock]
         for lock in locks {
             // start up 32 readers that block for 0.1 seconds each...
             for _ in 0 ..< 32 {


### PR DESCRIPTION
Depends on #7 and #12.

* Replaces use of GCD queues as a locking mechanism with a GCD semaphore.
   - GCD semaphores briefly spin, and so is in the same ballpark as `CASSpinLock` when actual readers/writer behavior isn't a concern.
* Without the capturing semantics of dispatch queue blocks, the locking protocol can be made to use `@noescape`
* Adds a `pthread_rwlock_t` implementation
   - An early version of this branch also had an `NSLock` conformance. SO. SLOW.

TODO:
- [ ] Consider if readers-writer behavior is actually necessary
- [ ] Optimization for setter critical path?
- [ ] Ponies?