### PR TITLE
Documentation sprint

### DIFF
--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -187,6 +187,11 @@ extension Deferred {
     Begins another asynchronous operation with the deferred value once it
     becomes determined.
     
+    `flatMap` is similar to `map`, but `transform` returns another `Deferred`
+    instead of an immediate value. Use `flatMap` when you want this deferred
+    value to feed into another asynchronous fetch. You might hear this referred
+    to as "chaining" or "binding".
+    
     :param: queue A dispatch queue for starting the new operation on.
     :param: transform A function to start a new deferred given the receiving
     value.
@@ -205,6 +210,9 @@ extension Deferred {
     
     /**
     Transforms the deferred value once it becomes determined.
+    
+    `map` executes a transform immediately when the deferred value is
+    determined.
     
     :param: queue A dispatch queue for executing the transform on.
     :param: transform A function to create something using the deferred value.

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -191,8 +191,7 @@ extension Deferred {
     :param: transform A function to start a new deferred given the receiving
     value.
     
-    :returns: A new deferred value that is determined once the receiving
-    deferred is determined by beginning some new operation using that value.
+    :returns: The new deferred value returned by the `transform`.
     **/
     public func flatMap<NewValue>(upon queue: dispatch_queue_t = DeferredDefaultQueue, transform: Value -> Deferred<NewValue>) -> Deferred<NewValue> {
         let d = Deferred<NewValue>()

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -32,8 +32,6 @@ public enum Timeout {
     /// Wait indefinitely.
     case Forever
     /// Wait for a given number of seconds.
-    ///
-    /// :note: An `.Interval(0.0)` will achieve different results from `.Now`.
     case Interval(NSTimeInterval)
 
     private var rawValue: dispatch_time_t {

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -119,7 +119,7 @@ public struct Deferred<Value> {
     Call some function once the value is determined.
     
     If the value is already determined, the function will be submitted to the
-    queue immediately. An `upon` call is alreadys executed asnychronously.
+    queue immediately. An `upon` call is always executed asynchronously.
     
     :param: queue A dispatch queue for executing the given function on.
     :param: function A function that uses the determined value.
@@ -188,10 +188,10 @@ extension Deferred {
     becomes determined.
     
     :param: queue A dispatch queue for starting the new operation on.
-    :param: transform A function to start a new deferred given the recieving
+    :param: transform A function to start a new deferred given the receiving
     value.
     
-    :returns: A new deferred value that is determined once the recieving
+    :returns: A new deferred value that is determined once the receiving
     deferred is determined by beginning some new operation using that value.
     **/
     public func flatMap<NewValue>(upon queue: dispatch_queue_t = DeferredDefaultQueue, transform: Value -> Deferred<NewValue>) -> Deferred<NewValue> {
@@ -209,7 +209,7 @@ extension Deferred {
     
     :param: queue A dispatch queue for executing the transform on.
     :param: transform A function to create something using the deferred value.
-    :returns: A new deferred value that is determined once the recieving
+    :returns: A new deferred value that is determined once the receiving
     deferred is determined.
     **/
     public func map<NewValue>(upon queue: dispatch_queue_t = DeferredDefaultQueue, transform: Value -> NewValue) -> Deferred<NewValue> {
@@ -223,7 +223,7 @@ extension Deferred {
 
 extension Deferred {
     /**
-    Composes the recieving value with another.
+    Composes the receiving value with another.
     
     :param: other Any other deferred value.
     

--- a/Deferred/DispatchBlockFlags.swift
+++ b/Deferred/DispatchBlockFlags.swift
@@ -10,24 +10,29 @@ import Dispatch
 
 extension dispatch_block_flags_t: RawOptionSetType {
 
+    /// The empty options set.
     public static var allZeros: dispatch_block_flags_t {
         return dispatch_block_flags_t(0)
     }
 
+    /// Convert from a bitmask of `UInt`.
     public init(rawValue: UInt) {
         self.init(rawValue)
     }
 
+    /// Create an instance initialized with `nil`.
     public init(nilLiteral: ()) {
         self.init(0)
     }
 
+    /// The corresponding bitwise value of the "raw" type.
     public var rawValue: UInt {
         return value
     }
 
 }
 
+/// Return true if `lhs` is equal to `rhs`.
 public func ==(lhs: dispatch_block_flags_t, rhs: dispatch_block_flags_t) -> Bool {
     return lhs.value == rhs.value
 }

--- a/Deferred/DispatchBlockFlags.swift
+++ b/Deferred/DispatchBlockFlags.swift
@@ -15,12 +15,12 @@ extension dispatch_block_flags_t: RawOptionSetType {
         return dispatch_block_flags_t(0)
     }
 
-    /// Convert from a bitmask of `UInt`.
+    /// Converts from a bitmask of `UInt`.
     public init(rawValue: UInt) {
         self.init(rawValue)
     }
 
-    /// Create an instance initialized with `nil`.
+    /// Creates an instance initialized with `nil`.
     public init(nilLiteral: ()) {
         self.init(0)
     }

--- a/Deferred/LockProtected.swift
+++ b/Deferred/LockProtected.swift
@@ -8,25 +8,45 @@
 
 import Foundation
 
+/// A `LockProtected` holds onto a value of type T, but only allows access to it
+/// from within a locking statement. This prevents accidental unsafe access when
+/// thread safety is desired..
 public final class LockProtected<T> {
     private var lock: ReadWriteLock
     private var item: T
 
+    /// Create the protected value with an initial item and a default lock.
     public convenience init(item: T) {
         self.init(item: item, lock: CASSpinLock())
     }
-
+    
+    /// Create the protected value with an initial item and a type implementing
+    /// a lock.
     public init(item: T, lock: ReadWriteLock) {
         self.item = item
         self.lock = lock
     }
-
+    
+    /**
+    Give read access to the item within the given function.
+    
+    :param: block A function that reads from the contained item.
+    :returns: The value returned from the given function.
+    */
     public func withReadLock<U>(block: T -> U) -> U {
         return lock.withReadLock { [unowned self] in
             return block(self.item)
         }
     }
 
+    /**
+    Give write access to the item within the given function.
+    
+    :param: block A function that writes to the contained item, and returns some
+    value.
+    
+    :returns: The value returned from the given function.
+    */
     public func withWriteLock<U>(block: (inout T) -> U) -> U {
         return lock.withWriteLock { [unowned self] in
             return block(&self.item)

--- a/Deferred/LockProtected.swift
+++ b/Deferred/LockProtected.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// A `LockProtected` holds onto a value of type T, but only allows access to it
 /// from within a locking statement. This prevents accidental unsafe access when
-/// thread safety is desired..
+/// thread safety is desired.
 public final class LockProtected<T> {
     private var lock: ReadWriteLock
     private var item: T

--- a/Deferred/LockProtected.swift
+++ b/Deferred/LockProtected.swift
@@ -33,9 +33,9 @@ public final class LockProtected<T> {
     :param: block A function that reads from the contained item.
     :returns: The value returned from the given function.
     */
-    public func withReadLock<U>(block: T -> U) -> U {
+    public func withReadLock<U>(body: T -> U) -> U {
         return lock.withReadLock { [unowned self] in
-            return block(self.item)
+            return body(self.item)
         }
     }
 
@@ -47,9 +47,9 @@ public final class LockProtected<T> {
     
     :returns: The value returned from the given function.
     */
-    public func withWriteLock<U>(block: (inout T) -> U) -> U {
+    public func withWriteLock<U>(body: (inout T) -> U) -> U {
         return lock.withWriteLock { [unowned self] in
-            return block(&self.item)
+            return body(&self.item)
         }
     }
 }

--- a/Deferred/ReadWriteLock.swift
+++ b/Deferred/ReadWriteLock.swift
@@ -8,16 +8,47 @@
 
 import Foundation
 
+/// A type that mutually excludes execution of code such that only one unit of
+/// code is running at any given time. An implementing type may choose to have
+/// readers-writer semantics, such that many readers can read at once, or lock
+/// around all reads and writes the same way.
 public protocol ReadWriteLock {
+    /**
+    Call `body()` with a reading lock.
+    
+    If the implementing type models a readers-writer lock, this function may
+    behave differently to `withWriteLock(_:)`.
+    
+    :param: body A function that reads a value while locked.
+    :returns: The value returned from the given function.
+    */
     func withReadLock<T>(@noescape body: () -> T) -> T
+    
+    /**
+    Call `body()` with a writing lock.
+    
+    If the implementing type models a readers-writer lock, this function may
+    behave differently to `withReadLock(_:)`.
+    
+    :param: body A function that writes a value while locked, then returns some
+    value.
+    
+    :returns: The value returned from the given function.
+    */
     func withWriteLock<T>(@noescape body: () -> T) -> T
 }
 
+/// A locking construct using a counting semaphore from Grand Central Dispatch.
+/// This locking type behaves the same for both read and write locks.
+///
+/// The semaphore lock performs comparably to a spinlock under little lock
+/// contention, and comparably to a platform lock under contention.
 public struct DispatchLock: ReadWriteLock {
     private let semaphore = dispatch_semaphore_create(1)
 
+    /// Create a normal instance.
     public init() {}
-
+    
     private func withLock<T>(@noescape body: () -> T) -> T {
         let result: T
         dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
@@ -25,19 +56,38 @@ public struct DispatchLock: ReadWriteLock {
         dispatch_semaphore_signal(semaphore)
         return result
     }
-
+    
+    /**
+    Call `body()` with a lock.
+    
+    :param: body A function that reads a value while locked.
+    :returns: The value returned from the given function.
+    */
     public func withReadLock<T>(@noescape body: () -> T) -> T {
         return withLock(body)
     }
-
+    
+    /**
+    Call `body()` with a lock.
+    
+    :param: body A function that writes a value while locked, then returns some
+    value.
+    
+    :returns: The value returned from the given function.
+    */
     public func withWriteLock<T>(@noescape body: () -> T) -> T {
         return withLock(body)
     }
 }
 
+/// A spin lock provided by Darwin, the low-level system under iOS and OS X.
+///
+/// A spin lock polls to check the state of the lock, which is much faster
+/// when there isn't contention but rapidly slows down otherwise.
 public final class SpinLock: ReadWriteLock {
     private var lock: UnsafeMutablePointer<OSSpinLock>
 
+    /// Allocate a normal spinlock.
     public init() {
         lock = UnsafeMutablePointer.alloc(1)
         lock.initialize(OS_SPINLOCK_INIT)
@@ -54,17 +104,32 @@ public final class SpinLock: ReadWriteLock {
         OSSpinLockUnlock(lock)
         return result
     }
-
+    
+    /**
+    Call `body()` with a lock.
+    
+    :param: body A function that reads a value while locked.
+    :returns: The value returned from the given function.
+    */
     public func withReadLock<T>(@noescape body: () -> T) -> T {
         return withLock(body)
     }
-
+    
+    /**
+    Call `body()` with a lock.
+    
+    :param: body A function that writes a value while locked, then returns some
+    value.
+    
+    :returns: The value returned from the given function.
+    */
     public func withWriteLock<T>(@noescape body: () -> T) -> T {
         return withLock(body)
     }
 }
 
-/// Test comment 2
+/// A custom spin-lock with readers-writer semantics. The spin lock will poll
+/// to check the state of the lock, allowing many readers at the same time.
 public final class CASSpinLock: ReadWriteLock {
     private struct Masks {
         static let WRITER_BIT: Int32         = 0x40000000
@@ -75,6 +140,7 @@ public final class CASSpinLock: ReadWriteLock {
 
     private var _state: UnsafeMutablePointer<Int32>
 
+    /// Allocate the spinlock.
     public init() {
         _state = UnsafeMutablePointer.alloc(1)
         _state.memory = 0
@@ -84,6 +150,16 @@ public final class CASSpinLock: ReadWriteLock {
         _state.dealloc(1)
     }
 
+    /**
+    Call `body()` with a writing lock.
+    
+    The given function is guaranteed to be called exclusively.
+    
+    :param: body A function that writes a value while locked, then returns some
+    value.
+    
+    :returns: The value returned from the given function.
+    */
     public func withWriteLock<T>(@noescape body: () -> T) -> T {
         // spin until we acquire write lock
         do {
@@ -119,7 +195,15 @@ public final class CASSpinLock: ReadWriteLock {
 
         return result
     }
-
+    
+    /**
+    Call `body()` with a reading lock.
+    
+    The given function may be called concurrently with reads on other threads.
+    
+    :param: body A function that reads a value while locked.
+    :returns: The value returned from the given function.
+    */
     public func withReadLock<T>(@noescape body: () -> T) -> T {
         // spin until we acquire read lock
         do {
@@ -155,9 +239,12 @@ public final class CASSpinLock: ReadWriteLock {
     }
 }
 
+/// A readers-writer lock provided by the platform implementation of the
+/// POSIX Threads standard. Read more: https://en.wikipedia.org/wiki/POSIX_Threads
 public final class PThreadReadWriteLock: ReadWriteLock {
     private var lock: UnsafeMutablePointer<pthread_rwlock_t>
 
+    /// Create the standard platform lock.
     public init() {
         lock = UnsafeMutablePointer.alloc(1)
         let status = pthread_rwlock_init(lock, nil)
@@ -169,7 +256,15 @@ public final class PThreadReadWriteLock: ReadWriteLock {
         assert(status == 0)
         lock.dealloc(1)
     }
-
+    
+    /**
+    Call `body()` with a reading lock.
+    
+    The given function may be called concurrently with reads on other threads.
+    
+    :param: body A function that reads a value while locked.
+    :returns: The value returned from the given function.
+    */
     public func withReadLock<T>(@noescape body: () -> T) -> T {
         let result: T
         pthread_rwlock_rdlock(lock)
@@ -177,7 +272,17 @@ public final class PThreadReadWriteLock: ReadWriteLock {
         pthread_rwlock_unlock(lock)
         return result
     }
-
+    
+    /**
+    Call `body()` with a writing lock.
+    
+    The given function is guaranteed to be called exclusively.
+    
+    :param: body A function that writes a value while locked, then returns some
+    value.
+    
+    :returns: The value returned from the given function.
+    */
     public func withWriteLock<T>(@noescape body: () -> T) -> T {
         let result: T
         pthread_rwlock_wrlock(lock)


### PR DESCRIPTION
Derived from #13. Provides documentation for all members, reaching 100% coverage under [Jazzy](https://github.com/realm/jazzy).

I produced an HTML docset in the repo directory with:

```shell
~/Downloads/jazzy/bin/jazzy -m Deferred -g https://github.com/bignerdranch/Deferred -a "Big Nerd Ranch" -u https://github.com/bignerdranch --module-version=1.2.0 -r http://bignerdranch.github.io/Deferred/docs/
```

Have at it. :fire: