### PR TITLE
Modernized front-facing API

### DIFF
--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -12,31 +12,50 @@ private var DeferredDefaultQueue: dispatch_queue_t {
     return dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
 }
 
+/// A deferred is a value that may become determined (or "filled") at some point
+/// in the future. Once a deferred value is determined, it cannot change.
 public struct Deferred<Value> {
     typealias UponBlock = (dispatch_queue_t, Value -> ())
     private typealias Protected = (protected: Value?, uponBlocks: [UponBlock])
-
+    
     private var protected: LockProtected<Protected>
-
+    
     private init(_ value: Value?) {
         protected = LockProtected(item: (value, []))
     }
-
-    // Initialize an unfilled Deferred
+    
+    /// Initialize an unfilled Deferred.
     public init() {
         self.init(nil)
     }
-
-    // Initialize a filled Deferred with the given value
+    
+    /// Initialize a filled Deferred with the given value.
     public init(value: Value) {
         self.init(value)
     }
-
-    // Check whether or not the receiver is filled
+    
+    /// Check whether or not the receiver is filled.
     public var isFilled: Bool {
         return protected.withReadLock { $0.protected != nil }
     }
     
+    /// Determines the deferred value with a given result.
+    ///
+    /// Filling a deferred value should usually be attempted only once, and by
+    /// default filling will trap upon improper usage.
+    ///
+    /// * In playgrounds and unoptimized builds (the default for a "Debug"
+    ///   configuration), program execution will be stopped at the caller in
+    ///   a debuggable state.
+    /// * In -O builds (the default for a "Release" configuration), program
+    ///   execution will stop.
+    /// * In -Ounchecked builds, the programming error is assumed to not exist.
+    ///
+    /// If your deferred requires multiple potential fillers to race, you may
+    /// disable the precondition.
+    ///
+    /// :param: value The resolved value of the deferred.
+    /// :param: assertIfFilled If `false`, race checking is disabled.
     public func fill(value: Value, assertIfFilled: Bool = true, file: StaticString = __FILE__, line: UWord = __LINE__) {
         let (filledValue, blocks) = protected.withWriteLock { data -> (Value, [UponBlock]) in
             if assertIfFilled {
@@ -53,11 +72,25 @@ public struct Deferred<Value> {
             dispatch_async(queue) { block(filledValue) }
         }
     }
-
+    
+    /**
+    Checks for and returns a determined value.
+    
+    :returns: The determined value, if already filled, or `nil`.
+    */
     public func peek() -> Value? {
         return protected.withReadLock { $0.protected }
     }
-
+    
+    /**
+    Call some function once the value is determined.
+    
+    If the value is already determined, the function will be submitted to the
+    queue immediately. An `upon` call is alreadys executed asnychronously.
+    
+    :param: queue A dispatch queue for executing the given function on.
+    :param: function A function that uses the determined value.
+    */
     public func upon(_ queue: dispatch_queue_t = DeferredDefaultQueue, function: Value -> ()) {
         let maybeValue: Value? = protected.withWriteLock{ data in
             if data.protected == nil {
@@ -72,6 +105,17 @@ public struct Deferred<Value> {
 }
 
 extension Deferred {
+    /**
+    Waits for the value to become determined, then returns it.
+
+    This is equivalent to unwrapping the value of calling `wait(.Forever)`, but
+    may be more efficient.
+
+    This getter will unnecessarily block execution. It might be useful for
+    testing, but otherwise it should be strictly avoided.
+
+    :returns: The determined value.
+    */
     public var value: Value {
         // fast path - return if already filled
         if let v = peek() {
@@ -89,6 +133,17 @@ extension Deferred {
 }
 
 extension Deferred {
+    /**
+    Begins another asynchronous operation with the deferred value once it
+    becomes determined.
+
+    :param: queue A dispatch queue for starting the new operation on.
+    :param: transform A function to start a new deferred given the recieving
+    value.
+
+    :returns: A new deferred value that is determined once the recieving
+    deferred is determined by beginning some new operation using that value.
+    **/
     public func flatMap<NewValue>(upon queue: dispatch_queue_t = DeferredDefaultQueue, transform: Value -> Deferred<NewValue>) -> Deferred<NewValue> {
         let d = Deferred<NewValue>()
         upon(queue) {
@@ -99,6 +154,14 @@ extension Deferred {
         return d
     }
 
+    /**
+    Transforms the deferred value once it becomes determined.
+
+    :param: queue A dispatch queue for executing the transform on.
+    :param: transform A function to create something using the deferred value.
+    :returns: A new deferred value that is determined once the recieving
+    deferred is determined.
+    **/
     public func map<NewValue>(upon queue: dispatch_queue_t = DeferredDefaultQueue, transform: Value -> NewValue) -> Deferred<NewValue> {
         let d = Deferred<NewValue>()
         upon(queue) {
@@ -109,11 +172,26 @@ extension Deferred {
 }
 
 extension Deferred {
+    /**
+    Composes the recieving value with another.
+
+    :param: other Any other deferred value.
+
+    :returns: A value that becomes determined after both the reciever and the
+    given values become determined.
+    */
     public func both<OtherValue>(other: Deferred<OtherValue>) -> Deferred<(Value, OtherValue)> {
         return flatMap { t in other.map { u in (t, u) } }
     }
 }
 
+/**
+Compose a number of deferred values into a single deferred array.
+
+:param: deferreds Any collection whose elements are themselves deferred values.
+:return: A deferred array that is determined once all the given values are
+determined, in the same order.
+**/
 public func all<Value, Collection: CollectionType where Collection.Generator.Element == Deferred<Value>>(deferreds: Collection) -> Deferred<[Value]> {
     let array = Array(deferreds)
     if array.isEmpty {
@@ -138,6 +216,13 @@ public func all<Value, Collection: CollectionType where Collection.Generator.Ele
     return combined
 }
 
+/**
+Choose the deferred value that is determined first.
+
+:param: deferreds Any collection whose elements are themselves deferred values.
+:return: A deferred value that is determined with the first of the given
+deferred values to be determined.
+**/
 public func any<Value, Sequence: SequenceType where Sequence.Generator.Element == Deferred<Value>>(deferreds: Sequence) -> Deferred<Deferred<Value>> {
     let combined = Deferred<Deferred<Value>>()
     for d in deferreds {

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -12,24 +12,24 @@ private var DeferredDefaultQueue: dispatch_queue_t {
     return dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
 }
 
-public final class Deferred<Value> {
+public struct Deferred<Value> {
     typealias UponBlock = (dispatch_queue_t, Value -> ())
     private typealias Protected = (protected: Value?, uponBlocks: [UponBlock])
 
     private var protected: LockProtected<Protected>
 
-    private init(value: Value?) {
+    private init(_ value: Value?) {
         protected = LockProtected(item: (value, []))
     }
 
     // Initialize an unfilled Deferred
-    public convenience init() {
-        self.init(value: nil)
+    public init() {
+        self.init(nil)
     }
 
     // Initialize a filled Deferred with the given value
-    public convenience init(value: Value) {
-        self.init(value: value)
+    public init(value: Value) {
+        self.init(value)
     }
 
     // Check whether or not the receiver is filled

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -114,7 +114,7 @@ extension Deferred {
 
 extension Deferred {
     public func both<OtherValue>(other: Deferred<OtherValue>) -> Deferred<(Value, OtherValue)> {
-        return self.flatMap { t in other.map { u in (t, u) } }
+        return flatMap { t in other.map { u in (t, u) } }
     }
 }
 

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -141,8 +141,7 @@ extension Deferred {
     :param: transform A function to start a new deferred given the receiving
     value.
 
-    :returns: A new deferred value that is determined once the receiving
-    deferred is determined by beginning some new operation using that value.
+    :returns: The new deferred value returned by the `transform`.
     **/
     public func flatMap<NewValue>(upon queue: dispatch_queue_t = DeferredDefaultQueue, transform: Value -> Deferred<NewValue>) -> Deferred<NewValue> {
         let d = Deferred<NewValue>()

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -99,28 +99,18 @@ extension Deferred {
 }
 
 extension Deferred {
-    public func bindQueue<U>(queue: dispatch_queue_t, f: T -> Deferred<U>) -> Deferred<U> {
+    public func bind<U>(upon queue: dispatch_queue_t = DeferredDefaultQueue, transform: T -> Deferred<U>) -> Deferred<U> {
         let d = Deferred<U>()
         upon(queue) {
-            f($0).upon(queue) {
+            transform($0).upon(queue) {
                 d.fill($0)
             }
         }
         return d
     }
 
-    public func mapQueue<U>(queue: dispatch_queue_t, f: T -> U) -> Deferred<U> {
-        return bindQueue(queue) { t in Deferred<U>(value: f(t)) }
-    }
-}
-
-extension Deferred {
-    public func bind<U>(f: T -> Deferred<U>) -> Deferred<U> {
-        return bindQueue(defaultQueue, f: f)
-    }
-
-    public func map<U>(f: T -> U) -> Deferred<U> {
-        return mapQueue(defaultQueue, f: f)
+    public func map<U>(upon queue: dispatch_queue_t = DeferredDefaultQueue, transform: T -> U) -> Deferred<U> {
+        return bind(upon: queue) { t in Deferred<U>(value: transform(t)) }
     }
 }
 

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -37,10 +37,10 @@ public struct Deferred<Value> {
         return protected.withReadLock { $0.protected != nil }
     }
     
-    public func fill(value: Value, assertIfFilled: Bool = true) {
+    public func fill(value: Value, assertIfFilled: Bool = true, file: StaticString = __FILE__, line: UWord = __LINE__) {
         let (filledValue, blocks) = protected.withWriteLock { data -> (Value, [UponBlock]) in
             if assertIfFilled {
-                precondition(data.protected == nil, "Cannot fill an already-filled Deferred")
+                precondition(data.protected == nil, "Cannot fill an already-filled Deferred", file: file, line: line)
                 data.protected = value
             } else if data.protected == nil {
                 data.protected = value

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -157,8 +157,8 @@ public func all<Value, Collection: CollectionType where Collection.Generator.Ele
     return combined
 }
 
-public func any<T>(deferreds: [Deferred<T>]) -> Deferred<Deferred<T>> {
-    let combined = Deferred<Deferred<T>>()
+public func any<Value, Sequence: SequenceType where Sequence.Generator.Element == Deferred<Value>>(deferreds: Sequence) -> Deferred<Deferred<Value>> {
+    let combined = Deferred<Deferred<Value>>()
     for d in deferreds {
         d.upon { _ in combined.fillIfUnfilled(d) }
     }

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -86,7 +86,7 @@ public struct Deferred<Value> {
     Call some function once the value is determined.
     
     If the value is already determined, the function will be submitted to the
-    queue immediately. An `upon` call is alreadys executed asnychronously.
+    queue immediately. An `upon` call is always executed asynchronously.
     
     :param: queue A dispatch queue for executing the given function on.
     :param: function A function that uses the determined value.
@@ -138,10 +138,10 @@ extension Deferred {
     becomes determined.
 
     :param: queue A dispatch queue for starting the new operation on.
-    :param: transform A function to start a new deferred given the recieving
+    :param: transform A function to start a new deferred given the receiving
     value.
 
-    :returns: A new deferred value that is determined once the recieving
+    :returns: A new deferred value that is determined once the receiving
     deferred is determined by beginning some new operation using that value.
     **/
     public func flatMap<NewValue>(upon queue: dispatch_queue_t = DeferredDefaultQueue, transform: Value -> Deferred<NewValue>) -> Deferred<NewValue> {
@@ -159,7 +159,7 @@ extension Deferred {
 
     :param: queue A dispatch queue for executing the transform on.
     :param: transform A function to create something using the deferred value.
-    :returns: A new deferred value that is determined once the recieving
+    :returns: A new deferred value that is determined once the receiving
     deferred is determined.
     **/
     public func map<NewValue>(upon queue: dispatch_queue_t = DeferredDefaultQueue, transform: Value -> NewValue) -> Deferred<NewValue> {
@@ -173,7 +173,7 @@ extension Deferred {
 
 extension Deferred {
     /**
-    Composes the recieving value with another.
+    Composes the receiving value with another.
 
     :param: other Any other deferred value.
 

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -137,6 +137,11 @@ extension Deferred {
     Begins another asynchronous operation with the deferred value once it
     becomes determined.
 
+    `flatMap` is similar to `map`, but `transform` returns another `Deferred`
+    instead of an immediate value. Use `flatMap` when you want this deferred
+    value to feed into another asynchronous fetch. You might hear this referred
+    to as "chaining" or "binding".
+
     :param: queue A dispatch queue for starting the new operation on.
     :param: transform A function to start a new deferred given the receiving
     value.
@@ -155,6 +160,9 @@ extension Deferred {
 
     /**
     Transforms the deferred value once it becomes determined.
+
+    `map` executes a transform immediately when the deferred value is
+    determined.
 
     :param: queue A dispatch queue for executing the transform on.
     :param: transform A function to create something using the deferred value.

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -9,7 +9,9 @@
 import Foundation
 
 // TODO: Replace this with a class var
-private var DeferredDefaultQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
+private var DeferredDefaultQueue: dispatch_queue_t {
+    return dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
+}
 
 public final class Deferred<T> {
     typealias UponBlock = (dispatch_queue_t, T -> ())

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -37,8 +37,8 @@ public final class Deferred<Value> {
     public var isFilled: Bool {
         return protected.withReadLock { $0.protected != nil }
     }
-
-    private func _fill(value: Value, assertIfFilled: Bool) {
+    
+    public func fill(value: Value, assertIfFilled: Bool = true) {
         let (filledValue, blocks) = protected.withWriteLock { data -> (Value, [UponBlock]) in
             if assertIfFilled {
                 precondition(data.protected == nil, "Cannot fill an already-filled Deferred")
@@ -55,12 +55,8 @@ public final class Deferred<Value> {
         }
     }
 
-    public func fill(value: Value) {
-        _fill(value, assertIfFilled: true)
-    }
-
     public func fillIfUnfilled(value: Value) {
-        _fill(value, assertIfFilled: false)
+        fill(value, assertIfFilled: false)
     }
 
     public func peek() -> Value? {

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2014-2015 Big Nerd Ranch. Licensed under MIT.
 //
 
-import Foundation
-
 // This cannot be a class var, new storage would be created for every
 // specialization. It also could not be used as a default argument as it is now.
 private var DeferredDefaultQueue: dispatch_queue_t {

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -99,7 +99,7 @@ extension Deferred {
 }
 
 extension Deferred {
-    public func bind<U>(upon queue: dispatch_queue_t = DeferredDefaultQueue, transform: T -> Deferred<U>) -> Deferred<U> {
+    public func flatMap<U>(upon queue: dispatch_queue_t = DeferredDefaultQueue, transform: T -> Deferred<U>) -> Deferred<U> {
         let d = Deferred<U>()
         upon(queue) {
             transform($0).upon(queue) {
@@ -110,13 +110,13 @@ extension Deferred {
     }
 
     public func map<U>(upon queue: dispatch_queue_t = DeferredDefaultQueue, transform: T -> U) -> Deferred<U> {
-        return bind(upon: queue) { t in Deferred<U>(value: transform(t)) }
+        return flatMap(upon: queue) { t in Deferred<U>(value: transform(t)) }
     }
 }
 
 extension Deferred {
     public func both<U>(other: Deferred<U>) -> Deferred<(T,U)> {
-        return self.bind { t in other.map { u in (t, u) } }
+        return self.flatMap { t in other.map { u in (t, u) } }
     }
 }
 

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -109,7 +109,11 @@ extension Deferred {
     }
 
     public func map<NewValue>(upon queue: dispatch_queue_t = DeferredDefaultQueue, transform: Value -> NewValue) -> Deferred<NewValue> {
-        return flatMap(upon: queue) { t in Deferred<NewValue>(value: transform(t)) }
+        let d = Deferred<NewValue>()
+        upon(queue) {
+            d.fill(transform($0))
+        }
+        return d
     }
 }
 

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-// TODO: Replace this with a class var
+// This cannot be a class var, new storage would be created for every
+// specialization. It also could not be used as a default argument as it is now.
 private var DeferredDefaultQueue: dispatch_queue_t {
     return dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
 }

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -54,10 +54,6 @@ public struct Deferred<Value> {
         }
     }
 
-    public func fillIfUnfilled(value: Value) {
-        fill(value, assertIfFilled: false)
-    }
-
     public func peek() -> Value? {
         return protected.withReadLock { $0.protected }
     }
@@ -145,7 +141,7 @@ public func all<Value, Collection: CollectionType where Collection.Generator.Ele
 public func any<Value, Sequence: SequenceType where Sequence.Generator.Element == Deferred<Value>>(deferreds: Sequence) -> Deferred<Deferred<Value>> {
     let combined = Deferred<Deferred<Value>>()
     for d in deferreds {
-        d.upon { _ in combined.fillIfUnfilled(d) }
+        d.upon { _ in combined.fill(d, assertIfFilled: false) }
     }
     return combined
 }

--- a/Deferred/LockProtected.swift
+++ b/Deferred/LockProtected.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// A `LockProtected` holds onto a value of type T, but only allows access to it
 /// from within a locking statement. This prevents accidental unsafe access when
-/// thread safety is desired..
+/// thread safety is desired.
 public final class LockProtected<T> {
     private var lock: ReadWriteLock
     private var item: T

--- a/Deferred/LockProtected.swift
+++ b/Deferred/LockProtected.swift
@@ -8,25 +8,45 @@
 
 import Foundation
 
+/// A `LockProtected` holds onto a value of type T, but only allows access to it
+/// from within a locking statement. This prevents accidental unsafe access when
+/// thread safety is desired..
 public final class LockProtected<T> {
     private var lock: ReadWriteLock
     private var item: T
 
+    /// Create the protected value with an initial item and a default lock.
     public convenience init(item: T) {
         self.init(item: item, lock: CASSpinLock())
     }
 
+    /// Create the protected value with an initial item and a type implementing
+    /// a lock.
     public init(item: T, lock: ReadWriteLock) {
         self.item = item
         self.lock = lock
     }
 
+    /**
+    Give read access to the item within the given function.
+
+    :param: block A function that reads from the contained item.
+    :returns: The value returned from the given function.
+    */
     public func withReadLock<U>(block: T -> U) -> U {
         return lock.withReadLock { [unowned self] in
             return block(self.item)
         }
     }
 
+    /**
+    Give write access to the item within the given function.
+
+    :param: block A function that writes to the contained item, and returns some
+    value.
+
+    :returns: The value returned from the given function.
+    */
     public func withWriteLock<U>(block: (inout T) -> U) -> U {
         return lock.withWriteLock { [unowned self] in
             return block(&self.item)

--- a/Deferred/LockProtected.swift
+++ b/Deferred/LockProtected.swift
@@ -33,9 +33,9 @@ public final class LockProtected<T> {
     :param: block A function that reads from the contained item.
     :returns: The value returned from the given function.
     */
-    public func withReadLock<U>(block: T -> U) -> U {
+    public func withReadLock<U>(body: T -> U) -> U {
         return lock.withReadLock { [unowned self] in
-            return block(self.item)
+            return body(self.item)
         }
     }
 
@@ -47,9 +47,9 @@ public final class LockProtected<T> {
 
     :returns: The value returned from the given function.
     */
-    public func withWriteLock<U>(block: (inout T) -> U) -> U {
+    public func withWriteLock<U>(body: (inout T) -> U) -> U {
         return lock.withWriteLock { [unowned self] in
-            return block(&self.item)
+            return body(&self.item)
         }
     }
 }

--- a/Deferred/ReadWriteLock.swift
+++ b/Deferred/ReadWriteLock.swift
@@ -8,14 +8,45 @@
 
 import Foundation
 
+/// A type that mutually excludes execution of code such that only one unit of
+/// code is running at any given time. An implementing type may choose to have
+/// readers-writer semantics, such that many readers can read at once, or lock
+/// around all reads and writes the same way.
 public protocol ReadWriteLock {
+    /**
+    Call `body()` with a reading lock.
+
+    If the implementing type models a readers-writer lock, this function may
+    behave differently to `withWriteLock(_:)`.
+
+    :param: body A function that reads a value while locked.
+    :returns: The value returned from the given function.
+    */
     func withReadLock<T>(@noescape body: () -> T) -> T
+
+    /**
+    Call `body()` with a writing lock.
+
+    If the implementing type models a readers-writer lock, this function may
+    behave differently to `withReadLock(_:)`.
+
+    :param: body A function that writes a value while locked, then returns some
+    value.
+
+    :returns: The value returned from the given function.
+    */
     func withWriteLock<T>(@noescape body: () -> T) -> T
 }
 
+/// A locking construct using a counting semaphore from Grand Central Dispatch.
+/// This locking type behaves the same for both read and write locks.
+///
+/// The semaphore lock performs comparably to a spinlock under little lock
+/// contention, and comparably to a platform lock under contention.
 public struct DispatchLock: ReadWriteLock {
     private let semaphore = dispatch_semaphore_create(1)
 
+    /// Create a normal instance.
     public init() {}
 
     private func withLock<T>(@noescape body: () -> T) -> T {
@@ -26,18 +57,37 @@ public struct DispatchLock: ReadWriteLock {
         return result
     }
 
+    /**
+    Call `body()` with a lock.
+
+    :param: body A function that reads a value while locked.
+    :returns: The value returned from the given function.
+    */
     public func withReadLock<T>(@noescape body: () -> T) -> T {
         return withLock(body)
     }
 
+    /**
+    Call `body()` with a lock.
+
+    :param: body A function that writes a value while locked, then returns some
+    value.
+
+    :returns: The value returned from the given function.
+    */
     public func withWriteLock<T>(@noescape body: () -> T) -> T {
         return withLock(body)
     }
 }
 
+/// A spin lock provided by Darwin, the low-level system under iOS and OS X.
+///
+/// A spin lock polls to check the state of the lock, which is much faster
+/// when there isn't contention but rapidly slows down otherwise.
 public final class SpinLock: ReadWriteLock {
     private var lock: UnsafeMutablePointer<OSSpinLock>
 
+    /// Allocate a normal spinlock.
     public init() {
         lock = UnsafeMutablePointer.alloc(1)
         lock.initialize(OS_SPINLOCK_INIT)
@@ -55,16 +105,31 @@ public final class SpinLock: ReadWriteLock {
         return result
     }
 
+    /**
+    Call `body()` with a lock.
+
+    :param: body A function that reads a value while locked.
+    :returns: The value returned from the given function.
+    */
     public func withReadLock<T>(@noescape body: () -> T) -> T {
         return withLock(body)
     }
 
+    /**
+    Call `body()` with a lock.
+
+    :param: body A function that writes a value while locked, then returns some
+    value.
+
+    :returns: The value returned from the given function.
+    */
     public func withWriteLock<T>(@noescape body: () -> T) -> T {
         return withLock(body)
     }
 }
 
-/// Test comment 2
+/// A custom spin-lock with readers-writer semantics. The spin lock will poll
+/// to check the state of the lock, allowing many readers at the same time.
 public final class CASSpinLock: ReadWriteLock {
     private struct Masks {
         static let WRITER_BIT: Int32         = 0x40000000
@@ -75,6 +140,7 @@ public final class CASSpinLock: ReadWriteLock {
 
     private var _state: UnsafeMutablePointer<Int32>
 
+    /// Allocate the spinlock.
     public init() {
         _state = UnsafeMutablePointer.alloc(1)
         _state.memory = 0
@@ -84,6 +150,16 @@ public final class CASSpinLock: ReadWriteLock {
         _state.dealloc(1)
     }
 
+    /**
+    Call `body()` with a writing lock.
+
+    The given function is guaranteed to be called exclusively.
+
+    :param: body A function that writes a value while locked, then returns some
+    value.
+
+    :returns: The value returned from the given function.
+    */
     public func withWriteLock<T>(@noescape body: () -> T) -> T {
         // spin until we acquire write lock
         do {
@@ -120,6 +196,14 @@ public final class CASSpinLock: ReadWriteLock {
         return result
     }
 
+    /**
+    Call `body()` with a reading lock.
+
+    The given function may be called concurrently with reads on other threads.
+
+    :param: body A function that reads a value while locked.
+    :returns: The value returned from the given function.
+    */
     public func withReadLock<T>(@noescape body: () -> T) -> T {
         // spin until we acquire read lock
         do {
@@ -155,9 +239,12 @@ public final class CASSpinLock: ReadWriteLock {
     }
 }
 
+/// A readers-writer lock provided by the platform implementation of the
+/// POSIX Threads standard. Read more: https://en.wikipedia.org/wiki/POSIX_Threads
 public final class PThreadReadWriteLock: ReadWriteLock {
     private var lock: UnsafeMutablePointer<pthread_rwlock_t>
 
+    /// Create the standard platform lock.
     public init() {
         lock = UnsafeMutablePointer.alloc(1)
         let status = pthread_rwlock_init(lock, nil)
@@ -170,6 +257,14 @@ public final class PThreadReadWriteLock: ReadWriteLock {
         lock.dealloc(1)
     }
 
+    /**
+    Call `body()` with a reading lock.
+
+    The given function may be called concurrently with reads on other threads.
+
+    :param: body A function that reads a value while locked.
+    :returns: The value returned from the given function.
+    */
     public func withReadLock<T>(@noescape body: () -> T) -> T {
         let result: T
         pthread_rwlock_rdlock(lock)
@@ -178,6 +273,16 @@ public final class PThreadReadWriteLock: ReadWriteLock {
         return result
     }
 
+    /**
+    Call `body()` with a writing lock.
+
+    The given function is guaranteed to be called exclusively.
+
+    :param: body A function that writes a value while locked, then returns some
+    value.
+
+    :returns: The value returned from the given function.
+    */
     public func withWriteLock<T>(@noescape body: () -> T) -> T {
         let result: T
         pthread_rwlock_wrlock(lock)

--- a/DeferredTests/DeferredTests.swift
+++ b/DeferredTests/DeferredTests.swift
@@ -71,10 +71,10 @@ class DeferredTests: XCTestCase {
         XCTAssertEqual(d.value, 1)
     }
 
-    func testFillIfUnfilled() {
+    func testFillMultipleTimes() {
         let d = Deferred(value: 1)
         XCTAssertEqual(d.value, 1)
-        d.fillIfUnfilled(2)
+        d.fill(2, assertIfFilled: false)
         XCTAssertEqual(d.value, 1)
     }
 
@@ -277,7 +277,7 @@ class DeferredTests: XCTestCase {
             beforeExpectation.fulfill()
         }
 
-        d.fillIfUnfilled(42)
+        d.fill(42, assertIfFilled: false)
 
         let afterExpectation = expectationWithDescription("stays filled with same optional")
         d.upon {

--- a/DeferredTests/DeferredTests.swift
+++ b/DeferredTests/DeferredTests.swift
@@ -267,4 +267,25 @@ class DeferredTests: XCTestCase {
 
         waitForExpectationsWithTimeout(0.5, handler: nil)
     }
+    
+    func testDeferredOptionalBehavesCorrectly() {
+        let d = Deferred<Optional<Int>>(value: .None)
+
+        let beforeExpectation = expectationWithDescription("already filled with nil optional")
+        d.upon {
+            XCTAssert($0 == .None)
+            beforeExpectation.fulfill()
+        }
+
+        d.fillIfUnfilled(42)
+
+        let afterExpectation = expectationWithDescription("stays filled with same optional")
+        d.upon {
+            XCTAssert($0 == .None)
+            afterExpectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(0.5, handler: nil)
+    }
+    
 }

--- a/DeferredTests/DeferredTests.swift
+++ b/DeferredTests/DeferredTests.swift
@@ -9,9 +9,9 @@
 import XCTest
 import Deferred
 
-func dispatch_main_after(interval: NSTimeInterval, block: () -> ()) {
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(NSTimeInterval(NSEC_PER_SEC)*interval)),
-            dispatch_get_main_queue(), block)
+func after(interval: NSTimeInterval, upon queue: dispatch_queue_t = dispatch_get_main_queue(), function: () -> ()) {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(NSTimeInterval(NSEC_PER_SEC) * interval)),
+        queue, function)
 }
 
 class DeferredTests: XCTestCase {
@@ -46,7 +46,7 @@ class DeferredTests: XCTestCase {
             _ = unfilled.value
             XCTFail("value did not block")
         }
-        dispatch_main_after(0.1) {
+        after(0.1) {
             expect.fulfill()
         }
         waitForExpectationsWithTimeout(1, handler: nil)
@@ -59,7 +59,7 @@ class DeferredTests: XCTestCase {
             XCTAssertEqual(d.value, 3)
             expect.fulfill()
         }
-        dispatch_main_after(0.1) {
+        after(0.1) {
             d.fill(3)
         }
         waitForExpectationsWithTimeout(1, handler: nil)
@@ -107,7 +107,7 @@ class DeferredTests: XCTestCase {
         }
 
         let expect = expectationWithDescription("upon blocks not called while deferred is unfilled")
-        dispatch_main_after(0.1) {
+        after(0.1) {
             expect.fulfill()
         }
 
@@ -126,7 +126,7 @@ class DeferredTests: XCTestCase {
             }
         }
 
-        dispatch_main_after(0.1) {
+        after(0.1) {
             d.fill(1)
         }
 
@@ -191,7 +191,7 @@ class DeferredTests: XCTestCase {
             d[i].fill(i)
         }
 
-        dispatch_main_after(0.1) {
+        after(0.1) {
             XCTAssertFalse(w.isFilled) // unfilled because d[0] is still unfilled
             d[0].fill(0)
 
@@ -229,7 +229,7 @@ class DeferredTests: XCTestCase {
             XCTAssertEqual(w.value.value, 3)
 
             d[4].fill(4)
-            dispatch_main_after(0.1) {
+            after(0.1) {
                 XCTAssertTrue(w.value === d[3])
                 XCTAssertEqual(w.value.value, 3)
                 expectation.fulfill()

--- a/DeferredTests/DeferredTests.swift
+++ b/DeferredTests/DeferredTests.swift
@@ -81,8 +81,14 @@ class DeferredTests: XCTestCase {
     func testIsFilled() {
         let d = Deferred<Int>()
         XCTAssertFalse(d.isFilled)
+
+        let expect = expectationWithDescription("isFilled is true when filled")
+        d.upon { _ in
+            XCTAssertTrue(d.isFilled)
+            expect.fulfill()
+        }
         d.fill(1)
-        XCTAssertTrue(d.isFilled)
+        waitForExpectationsWithTimeout(1, handler: nil)
     }
 
     func testUponWithFilled() {
@@ -126,9 +132,7 @@ class DeferredTests: XCTestCase {
             }
         }
 
-        after(0.1) {
-            d.fill(1)
-        }
+        d.fill(1)
 
         waitForExpectationsWithTimeout(1, handler: nil)
     }


### PR DESCRIPTION
* Renames and combines several methods in the spirit of Swift 2 and the stdlib.
* `any(_:)` and `all(_:)` now take any collection, such as the result of a `lazy(_:).filter(_:)` or so on.
   - `all` now short-circuits on empty collections.
   - `all(_:)` now uses a dispatch group for synchronization; tasks are executed in parallel.
* Increases documentation coverage
* For improved debugging, multiple `fill`s now trap in the caller's code, not in Deferred.
* Small performance improvement in `map`.