### PR TITLE
Removes the nested nature of the Deferreds with any

### DIFF
--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -243,10 +243,10 @@ Choose the deferred value that is determined first.
 :return: A deferred value that is determined with the first of the given
 deferred values to be determined.
 **/
-public func any<Value, Sequence: SequenceType where Sequence.Generator.Element == Deferred<Value>>(deferreds: Sequence) -> Deferred<Deferred<Value>> {
-    let combined = Deferred<Deferred<Value>>()
+public func any<Value, Sequence: SequenceType where Sequence.Generator.Element == Deferred<Value>>(deferreds: Sequence) -> Deferred<Value> {
+    let combined = Deferred<Value>()
     for d in deferreds {
-        d.upon { _ in combined.fill(d, assertIfFilled: false) }
+        d.upon { t in combined.fill(t, assertIfFilled: false) }
     }
     return combined
 }

--- a/DeferredTests/DeferredTests.swift
+++ b/DeferredTests/DeferredTests.swift
@@ -241,12 +241,12 @@ class DeferredTests: XCTestCase {
         let innerExpectation = expectationWithDescription("any is not changed")
 
         after(0.1) {
-            XCTAssertEqual(w.value.value, 3)
+            XCTAssertEqual(w.value, 3)
 
             d[4].fill(4)
 
             after(0.1) {
-                XCTAssertEqual(w.value.value, 3)
+                XCTAssertEqual(w.value, 3)
                 innerExpectation.fulfill()
             }
 


### PR DESCRIPTION
It seems that when using `any`, you are saying ... I don't care about which one comes back.  Tracking the `Deferred<Deferred<T>>` seems like overkill since I didn't care about the specific one.  If I do care about the specific one, then I could likely track it using a tuple or something more robust in the Result.

Working with the nested Deferreds seems to add more confusion than benefit, and as it stands now, it is more in parallel with the `all` function.