### PR TITLE
Replace spinning during Deferred tests (1.x)

### DIFF
--- a/DeferredTests/DeferredTests.swift
+++ b/DeferredTests/DeferredTests.swift
@@ -167,8 +167,9 @@ class DeferredTests: XCTestCase {
         d2.fill("foo")
 
         let expectation = expectationWithDescription("paired deferred should be filled")
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-            while (!both.isFilled) { /* spin */ }
+        both.upon { _ in
+            XCTAssert(d1.isFilled)
+            XCTAssert(d2.isFilled)
             XCTAssertEqual(both.value.0, 1)
             XCTAssertEqual(both.value.1, "foo")
             expectation.fulfill()
@@ -197,8 +198,7 @@ class DeferredTests: XCTestCase {
             XCTAssertFalse(w.isFilled) // unfilled because d[0] is still unfilled
             d[0].fill(0)
 
-            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-                while (!w.isFilled) { /* spin */ }
+            dispatch_main_after(0.1) {
                 XCTAssertTrue(w.value == [Int](0 ..< d.count))
                 innerExpectation.fulfill()
             }
@@ -215,27 +215,24 @@ class DeferredTests: XCTestCase {
     }
 
     func testAny() {
-        var d = [Deferred<Int>]()
-
-        for _ in 0 ..< 10 {
-            d.append(Deferred())
-        }
-
+        let d = map(0 ..< 10) { _ in Deferred<Int>() }
         let w = any(d)
 
         d[3].fill(3)
-        let expectation = expectationWithDescription("any is filled")
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-            while !w.isFilled { /* spin */ }
-            XCTAssertTrue(w.value === d[3])
+
+        let outerExpectation = expectationWithDescription("any is filled")
+        let innerExpectation = expectationWithDescription("any is not changed")
+
+        dispatch_main_after(0.1) {
             XCTAssertEqual(w.value.value, 3)
 
             d[4].fill(4)
             dispatch_main_after(0.1) {
                 XCTAssertTrue(w.value === d[3])
-                XCTAssertEqual(w.value.value, 3)
-                expectation.fulfill()
+                innerExpectation.fulfill()
             }
+
+            outerExpectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(testTimeout, handler: nil)


### PR DESCRIPTION
Fixes Swift 1.x tests on Travis. Working towards #35.