### PR TITLE
DeferredBuffer cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ xcuserdata
 *.xccheckout
 *.moved-aside
 *.xcuserstate
+*.xcscmblueprint
 
 ## Obj-C/Swift specific
 *.hmap

--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		DBA0D2F81B680F9E00A498CB /* DeferredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0F80AA1B680E7600394A66 /* DeferredTests.swift */; };
 		DBA0D2F91B680F9E00A498CB /* LockProtectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0F80AB1B680E7600394A66 /* LockProtectedTests.swift */; };
 		DBA0D2FA1B680F9E00A498CB /* ReadWriteLockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0F80AC1B680E7600394A66 /* ReadWriteLockTests.swift */; };
+		DBBC7E4B1C17E0BB004A6FDC /* MemoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBBC7E4A1C17E0BB004A6FDC /* MemoStore.swift */; };
+		DBBC7E4C1C17E0BB004A6FDC /* MemoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBBC7E4A1C17E0BB004A6FDC /* MemoStore.swift */; };
 		DBE3AD021BB452D200682E29 /* Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE3AD011BB452D200682E29 /* Timeout.swift */; };
 		DBE3AD031BB452D200682E29 /* Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE3AD011BB452D200682E29 /* Timeout.swift */; };
 /* End PBXBuildFile section */
@@ -84,6 +86,7 @@
 		DBA0D2E71B680F7E00A498CB /* DeferredTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DeferredTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DBA8376B1B98EBA100F3A2AE /* AnyFuture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyFuture.swift; sourceTree = "<group>"; };
 		DBA8376E1B98EDDC00F3A2AE /* AnyFutureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyFutureTests.swift; sourceTree = "<group>"; };
+		DBBC7E4A1C17E0BB004A6FDC /* MemoStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemoStore.swift; sourceTree = "<group>"; };
 		DBE3AD011BB452D200682E29 /* Timeout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Timeout.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -152,6 +155,7 @@
 				DB282A681B98B697008034C9 /* FutureType.swift */,
 				DB79DC3E1BE188C70071E070 /* IgnoringFuture.swift */,
 				DB0F80A21B680E6C00394A66 /* LockProtected.swift */,
+				DBBC7E4A1C17E0BB004A6FDC /* MemoStore.swift */,
 				DB282A6B1B98B815008034C9 /* PromiseType.swift */,
 				DB0F80A31B680E6C00394A66 /* ReadWriteLock.swift */,
 				DBE3AD011BB452D200682E29 /* Timeout.swift */,
@@ -363,6 +367,7 @@
 				DB282A691B98B697008034C9 /* FutureType.swift in Sources */,
 				DB282A751B98CE2C008034C9 /* FutureCollections.swift in Sources */,
 				DB282A6C1B98B815008034C9 /* PromiseType.swift in Sources */,
+				DBBC7E4B1C17E0BB004A6FDC /* MemoStore.swift in Sources */,
 				DB0F80A81B680E6C00394A66 /* ReadWriteLock.swift in Sources */,
 				DBE3AD021BB452D200682E29 /* Timeout.swift in Sources */,
 				DB79DC3A1BE188660071E070 /* AnyFuture.swift in Sources */,
@@ -379,6 +384,7 @@
 				DB282A6A1B98B697008034C9 /* FutureType.swift in Sources */,
 				DB282A761B98CE2C008034C9 /* FutureCollections.swift in Sources */,
 				DB282A6D1B98B815008034C9 /* PromiseType.swift in Sources */,
+				DBBC7E4C1C17E0BB004A6FDC /* MemoStore.swift in Sources */,
 				DB0F80A91B680E6C00394A66 /* ReadWriteLock.swift in Sources */,
 				DBE3AD031BB452D200682E29 /* Timeout.swift in Sources */,
 				DB79DC3B1BE188660071E070 /* AnyFuture.swift in Sources */,

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -39,17 +39,16 @@ private struct DispatchBlockMarker: CallbacksList {
 /// A deferred is a value that may become determined (or "filled") at some point
 /// in the future. Once a deferred value is determined, it cannot change.
 public struct Deferred<Value>: FutureType, PromiseType {
-    private var storage = MemoStore<Value, DispatchBlockMarker>.create()
+    private var storage: MemoStore<Value, DispatchBlockMarker>
     
     /// Initialize an unfilled Deferred.
     public init() {
-        storage.initializeWith(nil)
+        storage = MemoStore.create()
     }
     
     /// Initialize a filled Deferred with the given value.
     public init(value: Value) {
-        storage.initializeWith(value)
-        storage.onFilled.markCompleted()
+        storage = MemoStore.create(value)
     }
 
     // MARK: FutureType
@@ -115,7 +114,6 @@ public struct Deferred<Value>: FutureType, PromiseType {
     /// - parameter value: The resolved value for the instance.
     /// - returns: Whether the promise was fulfilled with `value`.
     public func fill(value: Value) -> Bool {
-        // TODO: integrate markCompleted() call into DeferredBuffers
-        return storage.fill(value, onFill: { $0.markCompleted() })
+        return storage.fill(value)
     }
 }

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -8,82 +8,6 @@
 
 import Dispatch
 
-// Atomic compare-and-swap, but safe for an initialize-once, owning pointer:
-//  - ObjC: "MyObject *__strong *"
-//  - Swift: "UnsafeMutablePointer<MyObject!>"
-// If the assignment is made, the new value is retained by its owning pointer.
-// If the assignment is not made, the new value is not retained.
-private func atomicInitialize<T: AnyObject>(target: UnsafeMutablePointer<T?>, to desired: T) -> Bool {
-    let newPtr = Unmanaged.passRetained(desired).toOpaque()
-    let wonRace = OSAtomicCompareAndSwapPtr(nil, UnsafeMutablePointer(newPtr), UnsafeMutablePointer(target))
-    if !wonRace {
-        Unmanaged.passUnretained(desired).release()
-    }
-    return wonRace
-}
-
-// In order to assign the value of a scalar in a Deferred using atomics, we must
-// box it up into something word-sized. See `atomicInitialize` above.
-private final class Box<T> {
-
-    let contents: T
-
-    init(_ contents: T) {
-        self.contents = contents
-    }
-
-}
-
-// Raw Deferred storage. Using `ManagedBuffer` has advantages over a custom class:
-//  - The side-table data is efficiently stored in tail-allocated buffer space.
-//  - The Element buffer has a stable pointer when locked to a single element.
-//  - Better holdsUniqueReference support allows for future optimization.
-private final class DeferredBuffer<Value, OnFill: CallbacksList>: ManagedBuffer<OnFill, Box<Value>?> {
-    
-    static func create() -> DeferredBuffer<Value, OnFill> {
-        return create(1, initialValue: { _ in
-            OnFill()
-        }) as! DeferredBuffer<Value, OnFill>
-    }
-    
-    deinit {
-        // super's deinit automatically destroys the Value
-        withUnsafeMutablePointerToElements { boxPtr in
-            // UnsafeMutablePointer.destroy() is faster than destroy(_:)
-            boxPtr.destroy()
-        }
-    }
-    
-    func initializeWith(value: Value?) {
-        let box = value.map(Box.init)
-        withUnsafeMutablePointerToElements { boxPtr in
-            boxPtr.initialize(box)
-        }
-    }
-    
-    func withValue(body: Value -> Void) {
-        withUnsafeMutablePointerToElements { boxPtr in
-            guard let box = boxPtr.memory else { return }
-            body(box.contents)
-        }
-    }
-    
-    func fill(value: Value, onFill: OnFill -> Void) -> Bool {
-        let box = Box(value)
-        return withUnsafeMutablePointers { (onFillPtr, boxPtr) in
-            guard atomicInitialize(boxPtr, to: box) else { return false }
-            onFill(onFillPtr.memory)
-            return true
-        }
-    }
-    
-    // The side-table data (our callbacks list) is ManagedBuffer.value.
-    var onFilled: OnFill {
-        return value
-    }
-    
-}
-
 // MARK: - DispatchBlockMarker
 
 // A dispatch block (which is different from a plain closure!) constitutes the
@@ -115,7 +39,7 @@ private struct DispatchBlockMarker: CallbacksList {
 /// A deferred is a value that may become determined (or "filled") at some point
 /// in the future. Once a deferred value is determined, it cannot change.
 public struct Deferred<Value>: FutureType, PromiseType {
-    private var storage = DeferredBuffer<Value, DispatchBlockMarker>.create()
+    private var storage = MemoStore<Value, DispatchBlockMarker>.create()
     
     /// Initialize an unfilled Deferred.
     public init() {

--- a/Deferred/Deferred.swift
+++ b/Deferred/Deferred.swift
@@ -43,12 +43,12 @@ public struct Deferred<Value>: FutureType, PromiseType {
     
     /// Initialize an unfilled Deferred.
     public init() {
-        storage = MemoStore.create()
+        storage = MemoStore.createWithValue(nil)
     }
     
     /// Initialize a filled Deferred with the given value.
     public init(value: Value) {
-        storage = MemoStore.create(value)
+        storage = MemoStore.createWithValue(value)
     }
 
     // MARK: FutureType

--- a/Deferred/MemoStore.swift
+++ b/Deferred/MemoStore.swift
@@ -60,7 +60,7 @@ final class MemoStore<Value, OnFill: CallbacksList> {
     //  - Better `holdsUniqueReference` support allows for future optimization.
     private typealias Manager = ManagedBufferPointer<OnFill, Box<Value>?>
     
-    static func create(value: Value? = nil) -> MemoStore<Value, OnFill> {
+    static func createWithValue(value: Value?) -> MemoStore<Value, OnFill> {
         let marker = OnFill()
         let boxed = value.map(Box.init)
         

--- a/Deferred/MemoStore.swift
+++ b/Deferred/MemoStore.swift
@@ -11,7 +11,6 @@ import Dispatch
 // Extremely simple surface describing an async rejoin-type notifier for a
 // one-off event.
 protocol CallbacksList {
-    
     init()
     
     var isCompleted: Bool { get }
@@ -27,5 +26,78 @@ protocol CallbacksList {
     /// If `isCompleted`, an implementer should immediately submit the `body`
     /// to `queue`.
     func notify(upon queue: dispatch_queue_t, body: dispatch_block_t)
+}
+
+// Atomic compare-and-swap, but safe for an initialize-once, owning pointer:
+//  - ObjC: "MyObject *__strong *"
+//  - Swift: "UnsafeMutablePointer<MyObject!>"
+// If the assignment is made, the new value is retained by its owning pointer.
+// If the assignment is not made, the new value is not retained.
+private func atomicInitialize<T: AnyObject>(target: UnsafeMutablePointer<T?>, to desired: T) -> Bool {
+    let newPtr = Unmanaged.passRetained(desired).toOpaque()
+    let wonRace = OSAtomicCompareAndSwapPtr(nil, UnsafeMutablePointer(newPtr), UnsafeMutablePointer(target))
+    if !wonRace {
+        Unmanaged.passUnretained(desired).release()
+    }
+    return wonRace
+}
+
+// In order to assign the value of a scalar in a Deferred using atomics, we must
+// box it up into something word-sized. See `atomicInitialize` above.
+private final class Box<T> {
+    let contents: T
     
+    init(_ contents: T) {
+        self.contents = contents
+    }
+}
+
+// Heap storage that is initialized with a value once-and-only-once, atomically.
+//
+// Using `ManagedBuffer` has advantages over a custom class:
+//  - The side-table data is efficiently stored in tail-allocated buffer space.
+//  - The Element buffer has a stable pointer when locked to a single element.
+//  - Better holdsUniqueReference support allows for future optimization.
+final class MemoStore<Value, OnFill: CallbacksList>: ManagedBuffer<OnFill, Box<Value>?> {
+    static func create() -> MemoStore<Value, OnFill> {
+        return create(1, initialValue: { _ in
+            OnFill()
+        }) as! MemoStore<Value, OnFill>
+    }
+    
+    deinit {
+        // super's deinit automatically destroys the Value
+        withUnsafeMutablePointerToElements { boxPtr in
+            // UnsafeMutablePointer.destroy() is faster than destroy(_:)
+            boxPtr.destroy()
+        }
+    }
+    
+    func initializeWith(value: Value?) {
+        let box = value.map(Box.init)
+        withUnsafeMutablePointerToElements { boxPtr in
+            boxPtr.initialize(box)
+        }
+    }
+    
+    func withValue(body: Value -> Void) {
+        withUnsafeMutablePointerToElements { boxPtr in
+            guard let box = boxPtr.memory else { return }
+            body(box.contents)
+        }
+    }
+    
+    func fill(value: Value, onFill: OnFill -> Void) -> Bool {
+        let box = Box(value)
+        return withUnsafeMutablePointers { (onFillPtr, boxPtr) in
+            guard atomicInitialize(boxPtr, to: box) else { return false }
+            onFill(onFillPtr.memory)
+            return true
+        }
+    }
+    
+    // The side-table data (our callbacks list) is ManagedBuffer.value.
+    var onFilled: OnFill {
+        return value
+    }
 }

--- a/Deferred/MemoStore.swift
+++ b/Deferred/MemoStore.swift
@@ -1,0 +1,31 @@
+//
+//  MemoStore.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 12/8/15.
+//  Copyright © 2014-2015 Big Nerd Ranch. Licensed under MIT.
+//
+
+import Dispatch
+
+// Extremely simple surface describing an async rejoin-type notifier for a
+// one-off event.
+protocol CallbacksList {
+    
+    init()
+    
+    var isCompleted: Bool { get }
+    
+    /// Unblock the waiter list.
+    ///
+    /// - precondition: `isCompleted` is false.
+    /// - postcondition: `isCompleted` is true.
+    func markCompleted()
+    
+    /// Become notified when the list becomes unblocked.
+    ///
+    /// If `isCompleted`, an implementer should immediately submit the `body`
+    /// to `queue`.
+    func notify(upon queue: dispatch_queue_t, body: dispatch_block_t)
+    
+}

--- a/Deferred/MemoStore.swift
+++ b/Deferred/MemoStore.swift
@@ -53,51 +53,66 @@ private final class Box<T> {
 }
 
 // Heap storage that is initialized with a value once-and-only-once, atomically.
-//
-// Using `ManagedBuffer` has advantages over a custom class:
-//  - The side-table data is efficiently stored in tail-allocated buffer space.
-//  - The Element buffer has a stable pointer when locked to a single element.
-//  - Better holdsUniqueReference support allows for future optimization.
-final class MemoStore<Value, OnFill: CallbacksList>: ManagedBuffer<OnFill, Box<Value>?> {
-    static func create() -> MemoStore<Value, OnFill> {
-        return create(1, initialValue: { _ in
-            OnFill()
-        }) as! MemoStore<Value, OnFill>
+final class MemoStore<Value, OnFill: CallbacksList> {
+    // Using `ManagedBufferPointer` has advantages over a custom class:
+    //  - The data is efficiently stored in tail-allocated buffer space.
+    //  - The buffer has a stable pointer when locked to a single element.
+    //  - Better `holdsUniqueReference` support allows for future optimization.
+    private typealias Manager = ManagedBufferPointer<OnFill, Box<Value>?>
+    
+    static func create(value: Value? = nil) -> MemoStore<Value, OnFill> {
+        let marker = OnFill()
+        let boxed = value.map(Box.init)
+        
+        // Create storage. Swift uses a two-stage tail-allocated system
+        // like ObjC's class_createInstance(2) with the extraBytes parameter.
+        let ptr = Manager(bufferClass: self, minimumCapacity: 1, initialValue: { (_, _) in
+            marker
+        })
+        
+        // Assign the initial value to managed storage
+        ptr.withUnsafeMutablePointerToElements {
+            $0.initialize(boxed)
+        }
+        
+        // Unblock the (empty) callbacks if needed.
+        // FIXME: Should there be a way to express that this could be done
+        // unsafely for performance? GCD doesn't need to.
+        if value != nil {
+            marker.markCompleted()
+        }
+        
+        // Kindly give back an instance of the ManagedBufferPointer's buffer - self.
+        return unsafeDowncast(ptr.buffer)
     }
+    
+    private init() {}
     
     deinit {
-        // super's deinit automatically destroys the Value
-        withUnsafeMutablePointerToElements { boxPtr in
-            // UnsafeMutablePointer.destroy() is faster than destroy(_:)
-            boxPtr.destroy()
-        }
-    }
-    
-    func initializeWith(value: Value?) {
-        let box = value.map(Box.init)
-        withUnsafeMutablePointerToElements { boxPtr in
-            boxPtr.initialize(box)
+        // UnsafeMutablePointer.destroy() is faster than destroy(_:) for single elements
+        Manager(unsafeBufferObject: self).withUnsafeMutablePointers {
+            $0.destroy()
+            $1.destroy()
         }
     }
     
     func withValue(body: Value -> Void) {
-        withUnsafeMutablePointerToElements { boxPtr in
+        Manager(unsafeBufferObject: self).withUnsafeMutablePointerToElements { boxPtr in
             guard let box = boxPtr.memory else { return }
             body(box.contents)
         }
     }
     
-    func fill(value: Value, onFill: OnFill -> Void) -> Bool {
+    func fill(value: Value) -> Bool {
         let box = Box(value)
-        return withUnsafeMutablePointers { (onFillPtr, boxPtr) in
+        return Manager(unsafeBufferObject: self).withUnsafeMutablePointers { (onFillPtr, boxPtr) in
             guard atomicInitialize(boxPtr, to: box) else { return false }
-            onFill(onFillPtr.memory)
+            onFillPtr.memory.markCompleted()
             return true
         }
     }
     
-    // The side-table data (our callbacks list) is ManagedBuffer.value.
     var onFilled: OnFill {
-        return value
+        return Manager(unsafeBufferObject: self).value
     }
 }

--- a/Deferred/MemoStore.swift
+++ b/Deferred/MemoStore.swift
@@ -85,8 +85,10 @@ final class MemoStore<Value, OnFill: CallbacksList> {
         // Kindly give back an instance of the ManagedBufferPointer's buffer - self.
         return unsafeDowncast(ptr.buffer)
     }
-    
-    private init() {}
+
+    private init() {
+        fatalError("Unavailable method cannot be called")
+    }
     
     deinit {
         // UnsafeMutablePointer.destroy() is faster than destroy(_:) for single elements


### PR DESCRIPTION
* Extricates use of `dispatch_block_t` scattered throughout `Deferred` and `DeferredBuffer` into a protocol-backed `CallbacksList` - part of #54.
* Refactors `DeferredBuffer` out into a different type for readability.
* Following Swift's [collections](https://github.com/apple/swift/blob/0b0123f39e9202e9a7adc2a1f242134720f9a79c/stdlib/public/core/Arrays.swift.gyb), uses `ManagedBufferPointer` over `ManagedBuffer`. Loses a little magic to be a little easier to read.