### PR TITLE
Rename AnyFuture, elevate IgnoringFuture

### DIFF
--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -21,10 +21,10 @@
 		DB282A761B98CE2C008034C9 /* FutureCollections.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB282A741B98CE2C008034C9 /* FutureCollections.swift */; };
 		DB3294FD1B68066C002160CC /* Deferred.h in Headers */ = {isa = PBXBuildFile; fileRef = DB3294FC1B68066C002160CC /* Deferred.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB3295541B680872002160CC /* Deferred.h in Headers */ = {isa = PBXBuildFile; fileRef = DB3294FC1B68066C002160CC /* Deferred.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DB79DC3A1BE188660071E070 /* AnyFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA8376B1B98EBA100F3A2AE /* AnyFuture.swift */; };
-		DB79DC3B1BE188660071E070 /* AnyFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA8376B1B98EBA100F3A2AE /* AnyFuture.swift */; };
-		DB79DC3C1BE1886B0071E070 /* AnyFutureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA8376E1B98EDDC00F3A2AE /* AnyFutureTests.swift */; };
-		DB79DC3D1BE1886C0071E070 /* AnyFutureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA8376E1B98EDDC00F3A2AE /* AnyFutureTests.swift */; };
+		DB79DC3A1BE188660071E070 /* ExistentialFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA8376B1B98EBA100F3A2AE /* ExistentialFuture.swift */; };
+		DB79DC3B1BE188660071E070 /* ExistentialFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA8376B1B98EBA100F3A2AE /* ExistentialFuture.swift */; };
+		DB79DC3C1BE1886B0071E070 /* ExistentialFutureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA8376E1B98EDDC00F3A2AE /* ExistentialFutureTests.swift */; };
+		DB79DC3D1BE1886C0071E070 /* ExistentialFutureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA8376E1B98EDDC00F3A2AE /* ExistentialFutureTests.swift */; };
 		DB79DC3F1BE188C70071E070 /* IgnoringFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB79DC3E1BE188C70071E070 /* IgnoringFuture.swift */; };
 		DB79DC401BE188C70071E070 /* IgnoringFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB79DC3E1BE188C70071E070 /* IgnoringFuture.swift */; };
 		DB79DC421BE188CF0071E070 /* IgnoringFutureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB79DC411BE188CF0071E070 /* IgnoringFutureTests.swift */; };
@@ -84,8 +84,8 @@
 		DB79DC411BE188CF0071E070 /* IgnoringFutureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IgnoringFutureTests.swift; sourceTree = "<group>"; };
 		DBA0D2D81B680F7400A498CB /* MobileDeferredTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MobileDeferredTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DBA0D2E71B680F7E00A498CB /* DeferredTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DeferredTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		DBA8376B1B98EBA100F3A2AE /* AnyFuture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyFuture.swift; sourceTree = "<group>"; };
-		DBA8376E1B98EDDC00F3A2AE /* AnyFutureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyFutureTests.swift; sourceTree = "<group>"; };
+		DBA8376B1B98EBA100F3A2AE /* ExistentialFuture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExistentialFuture.swift; sourceTree = "<group>"; };
+		DBA8376E1B98EDDC00F3A2AE /* ExistentialFutureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExistentialFutureTests.swift; sourceTree = "<group>"; };
 		DBBC7E4A1C17E0BB004A6FDC /* MemoStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemoStore.swift; sourceTree = "<group>"; };
 		DBE3AD011BB452D200682E29 /* Timeout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Timeout.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -149,7 +149,7 @@
 			isa = PBXGroup;
 			children = (
 				DB3294FC1B68066C002160CC /* Deferred.h */,
-				DBA8376B1B98EBA100F3A2AE /* AnyFuture.swift */,
+				DBA8376B1B98EBA100F3A2AE /* ExistentialFuture.swift */,
 				DB0F80A11B680E6C00394A66 /* Deferred.swift */,
 				DB282A741B98CE2C008034C9 /* FutureCollections.swift */,
 				DB282A681B98B697008034C9 /* FutureType.swift */,
@@ -167,7 +167,7 @@
 		DB3295431B680731002160CC /* DeferredTests */ = {
 			isa = PBXGroup;
 			children = (
-				DBA8376E1B98EDDC00F3A2AE /* AnyFutureTests.swift */,
+				DBA8376E1B98EDDC00F3A2AE /* ExistentialFutureTests.swift */,
 				DB0F80AA1B680E7600394A66 /* DeferredTests.swift */,
 				DB79DC411BE188CF0071E070 /* IgnoringFutureTests.swift */,
 				DB0F80AB1B680E7600394A66 /* LockProtectedTests.swift */,
@@ -370,7 +370,7 @@
 				DBBC7E4B1C17E0BB004A6FDC /* MemoStore.swift in Sources */,
 				DB0F80A81B680E6C00394A66 /* ReadWriteLock.swift in Sources */,
 				DBE3AD021BB452D200682E29 /* Timeout.swift in Sources */,
-				DB79DC3A1BE188660071E070 /* AnyFuture.swift in Sources */,
+				DB79DC3A1BE188660071E070 /* ExistentialFuture.swift in Sources */,
 				DB0F80A41B680E6C00394A66 /* Deferred.swift in Sources */,
 				DB0F80A61B680E6C00394A66 /* LockProtected.swift in Sources */,
 				DB79DC3F1BE188C70071E070 /* IgnoringFuture.swift in Sources */,
@@ -387,7 +387,7 @@
 				DBBC7E4C1C17E0BB004A6FDC /* MemoStore.swift in Sources */,
 				DB0F80A91B680E6C00394A66 /* ReadWriteLock.swift in Sources */,
 				DBE3AD031BB452D200682E29 /* Timeout.swift in Sources */,
-				DB79DC3B1BE188660071E070 /* AnyFuture.swift in Sources */,
+				DB79DC3B1BE188660071E070 /* ExistentialFuture.swift in Sources */,
 				DB0F80A51B680E6C00394A66 /* Deferred.swift in Sources */,
 				DB0F80A71B680E6C00394A66 /* LockProtected.swift in Sources */,
 				DB79DC401BE188C70071E070 /* IgnoringFuture.swift in Sources */,
@@ -399,7 +399,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DBA0D2F81B680F9E00A498CB /* DeferredTests.swift in Sources */,
-				DB79DC3D1BE1886C0071E070 /* AnyFutureTests.swift in Sources */,
+				DB79DC3D1BE1886C0071E070 /* ExistentialFutureTests.swift in Sources */,
 				DB79DC431BE188CF0071E070 /* IgnoringFutureTests.swift in Sources */,
 				DBA0D2F91B680F9E00A498CB /* LockProtectedTests.swift in Sources */,
 				DBA0D2FA1B680F9E00A498CB /* ReadWriteLockTests.swift in Sources */,
@@ -411,7 +411,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DBA0D2F51B680F9D00A498CB /* DeferredTests.swift in Sources */,
-				DB79DC3C1BE1886B0071E070 /* AnyFutureTests.swift in Sources */,
+				DB79DC3C1BE1886B0071E070 /* ExistentialFutureTests.swift in Sources */,
 				DB79DC421BE188CF0071E070 /* IgnoringFutureTests.swift in Sources */,
 				DBA0D2F61B680F9D00A498CB /* LockProtectedTests.swift in Sources */,
 				DBA0D2F71B680F9D00A498CB /* ReadWriteLockTests.swift in Sources */,

--- a/Deferred/AnyFuture.swift
+++ b/Deferred/AnyFuture.swift
@@ -16,7 +16,7 @@ for `FutureType`. The techniques were derived from experimenting with
 */
 
 // Abstract class that fake-conforms to `FutureType` for use by `AnyFuture`.
-class FutureBoxBase<Value>: FutureType {
+private class FutureBoxBase<Value>: FutureType {
     func upon(queue: dispatch_queue_t, body: Value -> ()) {
         fatalError()
     }
@@ -76,23 +76,20 @@ private final class FilledFutureBox<Value>: FutureBoxBase<Value> {
 ///   using the `PromiseType` aspect.
 public struct AnyFuture<Value>: FutureType {
     private let box: FutureBoxBase<Value>
-    init(box: FutureBoxBase<Value>) {
-        self.box = box
-    }
 
     /// Create a future whose `upon(_:function:)` method forwards to `base`.
     public init<Future: FutureType where Future.Value == Value>(_ base: Future) {
-        self.init(box: AnyFutureBox(base: base))
+        self.box = AnyFutureBox(base: base)
     }
 
     /// Wrap and forward future as if it were always filled with `value`.
     public init(_ value: Value) {
-        self.init(box: FilledFutureBox(value: value))
+        self.box = FilledFutureBox(value: value)
     }
     
     /// Create an `AnyFuture` having the same underlying future as `other`.
     public init(_ other: AnyFuture<Value>) {
-        self.init(box: other.box)
+        self.box = other.box
     }
 
     /// Call some function once the underlying future's value is determined.

--- a/Deferred/FutureCollections.swift
+++ b/Deferred/FutureCollections.swift
@@ -13,14 +13,14 @@ public extension SequenceType where Generator.Element: FutureType {
     ///
     /// - returns: A deferred value that is determined with the first of the
     ///   given futures to be determined.
-    var earliestFilled: AnyFuture<Generator.Element.Value> {
+    var earliestFilled: Future<Generator.Element.Value> {
         let combined = Deferred<Generator.Element.Value>()
         for future in self {
             future.upon {
                 combined.fill($0)
             }
         }
-        return AnyFuture(combined)
+        return Future(combined)
     }
 }
 
@@ -29,9 +29,9 @@ public extension CollectionType where Generator.Element: FutureType {
     ///
     /// - returns: A deferred array that is determined once all the given values
     ///   are determined, in the same order.
-    var joinedValues: AnyFuture<[Generator.Element.Value]> {
+    var joinedValues: Future<[Generator.Element.Value]> {
         if isEmpty {
-            return AnyFuture([])
+            return Future([])
         }
 
         let array = Array(self)
@@ -51,6 +51,6 @@ public extension CollectionType where Generator.Element: FutureType {
             })
         }
 
-        return AnyFuture(combined)
+        return Future(combined)
     }
 }

--- a/Deferred/FutureType.swift
+++ b/Deferred/FutureType.swift
@@ -160,8 +160,8 @@ public extension FutureType {
     /// - returns: A value that becomes determined after both the reciever and
     ///   the given future become determined.
     /// - seealso: SequenceType.allFutures
-    func and<OtherFuture: FutureType>(other: OtherFuture) -> AnyFuture<(Value, OtherFuture.Value)> {
-        return AnyFuture(flatMap { t in other.map { u in (t, u) } })
+    func and<OtherFuture: FutureType>(other: OtherFuture) -> Future<(Value, OtherFuture.Value)> {
+        return Future(flatMap { t in other.map { u in (t, u) } })
     }
     
     /// Composes this future with others.
@@ -171,8 +171,8 @@ public extension FutureType {
     /// - returns: A value that becomes determined after the reciever and both
     ///   other futures become determined.
     /// - seealso: SequenceType.allFutures
-    func and<Other1: FutureType, Other2: FutureType>(one: Other1, _ two: Other2) -> AnyFuture<(Value, Other1.Value, Other2.Value)> {
-        return AnyFuture(flatMap { t in
+    func and<Other1: FutureType, Other2: FutureType>(one: Other1, _ two: Other2) -> Future<(Value, Other1.Value, Other2.Value)> {
+        return Future(flatMap { t in
             one.flatMap { u in
                 two.map { v in (t, u, v) }
             }
@@ -187,8 +187,8 @@ public extension FutureType {
     /// - returns: A value that becomes determined after the reciever and both
     ///   other futures become determined.
     /// - seealso: SequenceType.allFutures
-    func and<Other1: FutureType, Other2: FutureType, Other3: FutureType>(one: Other1, _ two: Other2, _ three: Other3) -> AnyFuture<(Value, Other1.Value, Other2.Value, Other3.Value)> {
-        return AnyFuture(flatMap { t in
+    func and<Other1: FutureType, Other2: FutureType, Other3: FutureType>(one: Other1, _ two: Other2, _ three: Other3) -> Future<(Value, Other1.Value, Other2.Value, Other3.Value)> {
+        return Future(flatMap { t in
             one.flatMap { u in
                 two.flatMap { v in
                     three.map { w in (t, u, v, w) }

--- a/DeferredTests/ExistentialFutureTests.swift
+++ b/DeferredTests/ExistentialFutureTests.swift
@@ -1,5 +1,5 @@
 //
-//  AnyFutureTests.swift
+//  ExistentialFutureTests.swift
 //  Deferred
 //
 //  Created by Zachary Waldowski on 9/3/15.
@@ -9,9 +9,9 @@
 import XCTest
 @testable import Deferred
 
-class AnyFutureTests: XCTestCase {
+class ExistentialFutureTests: XCTestCase {
 
-    var anyFuture: AnyFuture<Int>!
+    var anyFuture: Future<Int>!
 
     override func tearDown() {
         anyFuture = nil
@@ -20,14 +20,14 @@ class AnyFutureTests: XCTestCase {
     }
 
     func testFilledAnyFutureWaitAlwaysReturns() {
-        anyFuture = AnyFuture(42)
+        anyFuture = Future(42)
         let peek = anyFuture.wait(.Forever)
         XCTAssertNotNil(peek)
     }
 
     func testAnyWaitWithTimeout() {
         let deferred = Deferred<Int>()
-        anyFuture = AnyFuture(deferred)
+        anyFuture = Future(deferred)
 
         let expect = expectationWithDescription("value blocks while unfilled")
         after(1, upon: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
@@ -42,7 +42,7 @@ class AnyFutureTests: XCTestCase {
     }
 
     func testFilledAnyFutureUpon() {
-        let d = AnyFuture(1)
+        let d = Future(1)
 
         for _ in 0 ..< 10 {
             let expect = expectationWithDescription("upon blocks called with correct value")
@@ -57,7 +57,7 @@ class AnyFutureTests: XCTestCase {
 
     func testUnfilledAnyUponCalledWhenFilled() {
         let d = Deferred<Int>()
-        anyFuture = AnyFuture(d)
+        anyFuture = Future(d)
 
         for _ in 0 ..< 10 {
             let expect = expectationWithDescription("upon blocks not called while deferred is unfilled")

--- a/DeferredTests/IgnoringFutureTests.swift
+++ b/DeferredTests/IgnoringFutureTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class IgnoringFutureTests: XCTestCase {
 
-    var future: AnyFuture<Void>!
+    var future: IgnoringFuture<Deferred<Int>>!
 
     override func tearDown() {
         future = nil
@@ -21,7 +21,7 @@ class IgnoringFutureTests: XCTestCase {
 
     func testWaitWithTimeout() {
         let deferred = Deferred<Int>()
-        future = deferred.ignoringValue
+        future = IgnoringFuture(deferred)
 
         let expect = expectationWithDescription("value blocks while unfilled")
         after(1, upon: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
@@ -37,7 +37,7 @@ class IgnoringFutureTests: XCTestCase {
 
     func testIgnoredUponCalledWhenFilled() {
         let d = Deferred<Int>()
-        future = d.ignoringValue
+        future = IgnoringFuture(d)
 
         for _ in 0 ..< 10 {
             let expect = expectationWithDescription("upon blocks not called while deferred is unfilled")


### PR DESCRIPTION
I could've sworn I filed an issue for this earlier, but it seems I never submitted it.

* Since it's mostly the API we already want, rename `AnyFuture` to just `Future`. If we want to have `Future` be a simpler implementation that owns something private and mutable, and just kill `Deferred` entirely, this provides forward coverage for that.
* Marking `FutureBoxBase` as anything but `private` is a code smell. Like `FlattenSequence`, `EnumerateSequence`, etc. in the stdlib, `IgnoringFuture` should wrap the type directly and not care about type erasure.