### PR TITLE
Atomics shimming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ## Build generated
+.build/
 build/
 DerivedData
 docs/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 build/
 DerivedData
 docs/
+Packages/
 
 ## Various settings
 *.pbxuser

--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -423,7 +423,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "Big Nerd Ranch";
 				TargetAttributes = {
 					DB6ADFD21C237DD500D77BF1 = {
@@ -654,6 +654,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB6AE0341C237E1F00D77BF1 /* Debug.xcconfig */;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -849,6 +851,7 @@
 				DB6AE0051C237DF800D77BF1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		DB6AE0061C237DF800D77BF1 /* Build configuration list for PBXNativeTarget "DeferredTests" */ = {
 			isa = XCConfigurationList;
@@ -857,6 +860,7 @@
 				DB6AE0081C237DF800D77BF1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		DB6AE01F1C237E0400D77BF1 /* Build configuration list for PBXNativeTarget "TVDeferred" */ = {
 			isa = XCConfigurationList;
@@ -865,6 +869,7 @@
 				DB6AE0211C237E0400D77BF1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		DB6AE0221C237E0400D77BF1 /* Build configuration list for PBXNativeTarget "TVDeferredTests" */ = {
 			isa = XCConfigurationList;
@@ -873,6 +878,7 @@
 				DB6AE0241C237E0400D77BF1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		DB6AE02F1C237E1300D77BF1 /* Build configuration list for PBXNativeTarget "NanoDeferred" */ = {
 			isa = XCConfigurationList;
@@ -881,6 +887,7 @@
 				DB6AE0311C237E1300D77BF1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Deferred.xcodeproj/xcshareddata/xcschemes/Deferred.xcscheme
+++ b/Deferred.xcodeproj/xcshareddata/xcschemes/Deferred.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -11,7 +11,8 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "YES"
+            hideIssues = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DB6ADFF11C237DF800D77BF1"
@@ -25,7 +26,8 @@
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "YES"
+            hideIssues = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DB6ADFFA1C237DF800D77BF1"

--- a/Deferred.xcodeproj/xcshareddata/xcschemes/MobileDeferred.xcscheme
+++ b/Deferred.xcodeproj/xcshareddata/xcschemes/MobileDeferred.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -11,7 +11,8 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "YES"
+            hideIssues = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DB6ADFD21C237DD500D77BF1"
@@ -25,7 +26,8 @@
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "YES"
+            hideIssues = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DB6ADFDC1C237DD500D77BF1"

--- a/Deferred.xcodeproj/xcshareddata/xcschemes/NanoDeferred.xcscheme
+++ b/Deferred.xcodeproj/xcshareddata/xcschemes/NanoDeferred.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -11,7 +11,8 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "YES"
+            hideIssues = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DB6AE0291C237E1300D77BF1"

--- a/Deferred.xcodeproj/xcshareddata/xcschemes/TVDeferred.xcscheme
+++ b/Deferred.xcodeproj/xcshareddata/xcschemes/TVDeferred.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -11,7 +11,8 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "YES"
+            hideIssues = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DB6AE00D1C237E0400D77BF1"
@@ -25,7 +26,8 @@
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "YES"
+            hideIssues = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DB6AE0161C237E0400D77BF1"

--- a/Package.swift
+++ b/Package.swift
@@ -13,5 +13,7 @@ let package = Package(
     targets: [
         Target(name: "Deferred", dependencies: []),
     ],
-    dependencies: []
+    dependencies: [
+	    .Package(url: "https://github.com/bignerdranch/AtomicSwift.git", majorVersion: 1)
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+//
+//  Package.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 12/7/15.
+//  Copyright © 2014-2015 Big Nerd Ranch. Licensed under MIT.
+//
+
+import PackageDescription
+
+let package = Package(
+    name: "Deferred",
+    targets: [
+        Target(name: "Deferred", dependencies: []),
+    ],
+    dependencies: []
+)

--- a/Sources/Deferred.h
+++ b/Sources/Deferred.h
@@ -11,3 +11,14 @@ extern double DeferredVersionNumber;
 
 //! Project version string for Deferred.
 extern const unsigned char DeferredVersionString[];
+
+// https://github.com/bignerdranch/AtomicSwift/blob/master/AtomicSwift.h
+static inline void __attribute__((always_inline, used)) _OSAtomicSpin(void) {
+#if defined(__x86_64__) || defined(__i386__)
+    __asm__ __volatile__("pause" ::: "memory");
+#elif defined(__arm__) || defined(__arm64__)
+    __asm__ __volatile__("yield" ::: "memory");
+#else
+    do {} while (0);
+#endif
+}

--- a/Sources/MemoStore.swift
+++ b/Sources/MemoStore.swift
@@ -7,6 +7,9 @@
 //
 
 import Dispatch
+#if SWIFT_PACKAGE
+import AtomicSwift
+#endif
 
 // Extremely simple surface describing an async rejoin-type notifier for a
 // one-off event.

--- a/Sources/ReadWriteLock.swift
+++ b/Sources/ReadWriteLock.swift
@@ -7,6 +7,9 @@
 //
 
 import Dispatch
+#if SWIFT_PACKAGE
+import AtomicSwift
+#endif
 
 /// A type that mutually excludes execution of code such that only one unit of
 /// code is running at any given time. An implementing type may choose to have

--- a/Sources/ReadWriteLock.swift
+++ b/Sources/ReadWriteLock.swift
@@ -101,24 +101,25 @@ public final class SpinLock: ReadWriteLock {
 /// A custom spin-lock with readers-writer semantics. The spin lock will poll
 /// to check the state of the lock, allowing many readers at the same time.
 public final class CASSpinLock: ReadWriteLock {
-    private struct Masks {
-        static let WRITER_BIT: Int32         = 0x40000000
-        static let WRITER_WAITING_BIT: Int32 = 0x20000000
-        static let MASK_WRITER_BITS          = WRITER_BIT | WRITER_WAITING_BIT
-        static let MASK_READER_BITS          = ~MASK_WRITER_BITS
+    // Original inspiration: http://joeduffyblog.com/2009/01/29/a-singleword-readerwriter-spin-lock/
+    // Updated/optimized version: https://jfdube.wordpress.com/2014/01/12/optimizing-the-recursive-read-write-spinlock/
+    private enum Constants {
+        static var WriterMask:   Int32 { return Int32(bitPattern: 0xFFF00000) }
+        static var ReaderMask:   Int32 { return Int32(bitPattern: 0x000FFFFF) }
+        static var WriterOffset: Int32 { return Int32(bitPattern: 0x00100000) }
     }
 
-    private var _state: UnsafeMutablePointer<Int32>
+    private var state: UnsafeMutablePointer<Int32>
 
     /// Allocate the spinlock.
     public init() {
-        _state = UnsafeMutablePointer.alloc(1)
-        _state.initialize(0)
+        state = UnsafeMutablePointer.alloc(1)
+        state.initialize(0)
     }
 
     deinit {
-        _state.destroy()
-        _state.dealloc(1)
+        state.destroy()
+        state.dealloc(1)
     }
 
     /// Call `body` with a writing lock.
@@ -130,36 +131,31 @@ public final class CASSpinLock: ReadWriteLock {
     public func withWriteLock<Return>(@noescape body: () throws -> Return) rethrows -> Return {
         // spin until we acquire write lock
         repeat {
-            let state = _state.memory
-
-            // if there are no readers and no one holds the write lock, try to grab the write lock immediately
-            if (state == 0 || state == Masks.WRITER_WAITING_BIT) &&
-                OSAtomicCompareAndSwap32Barrier(state, Masks.WRITER_BIT, _state) {
-                    break
+            // wait for any active writer to release the lock
+            while (state.memory & Constants.WriterMask) != 0 {
+                _OSAtomicSpin()
             }
 
-            // If we get here, someone is reading or writing. Set the WRITER_WAITING_BIT if
-            // it isn't already to block any new readers, then wait a bit before
-            // trying again. Ignore CAS failure - we'll just try again next iteration
-            if state & Masks.WRITER_WAITING_BIT == 0 {
-                OSAtomicCompareAndSwap32Barrier(state, state | Masks.WRITER_WAITING_BIT, _state)
+            // increment the writer count
+            if (OSAtomicAdd32Barrier(Constants.WriterOffset, state) & Constants.WriterMask) == Constants.WriterOffset {
+                // wait until there are no more readers
+                while (state.memory & Constants.ReaderMask) != 0 {
+                    _OSAtomicSpin()
+                }
+
+                // write lock acquired
+                break
             }
+
+            // there's another writer active; try again
+            OSAtomicAdd32Barrier(-Constants.WriterOffset, state)
         } while true
         
         defer {
-            // unlock
-            repeat {
-                let state = _state.memory
-                
-                // clear everything except (possibly) WRITER_WAITING_BIT, which will only be set
-                // if another writer is already here and waiting (which will keep out readers)
-                if OSAtomicCompareAndSwap32Barrier(state, state & Masks.WRITER_WAITING_BIT, _state) {
-                    break
-                }
-            } while true
+            // decrement writers, potentially unblock readers
+            OSAtomicAdd32Barrier(-Constants.WriterOffset, state)
         }
 
-        // write lock acquired - run block
         return try body()
     }
 
@@ -172,34 +168,26 @@ public final class CASSpinLock: ReadWriteLock {
     public func withReadLock<Return>(@noescape body: () throws -> Return) rethrows -> Return {
         // spin until we acquire read lock
         repeat {
-            let state = _state.memory
-
-            // if there is no writer and no writer waiting, try to increment reader count
-            if (state & Masks.MASK_WRITER_BITS) == 0 &&
-                OSAtomicCompareAndSwap32Barrier(state, state + 1, _state) {
-                    break
+            // wait for active writer to release the lock
+            while (state.memory & Constants.WriterMask) != 0 {
+                _OSAtomicSpin()
             }
+
+            // increment the reader count
+            if (OSAtomicIncrement32Barrier(state) & Constants.WriterMask) == 0 {
+                // read lock required
+                break
+            }
+
+            // a writer became active while locking; try again
+            OSAtomicDecrement32Barrier(state)
         } while true
         
         defer {
-            // decrement reader count
-            repeat {
-                let state = _state.memory
-                
-                // sanity check that we have a positive reader count before decrementing it
-                assert((state & Masks.MASK_READER_BITS) > 0, "unlocking read lock - invalid reader count")
-                
-                // desired new state: 1 fewer reader, preserving whether or not there is a writer waiting
-                let newState = ((state & Masks.MASK_READER_BITS) - 1) |
-                    (state & Masks.WRITER_WAITING_BIT)
-                
-                if OSAtomicCompareAndSwap32Barrier(state, newState, _state) {
-                    break
-                }
-            } while true
+            // decrement readers, potentially unblock writers
+            OSAtomicDecrement32Barrier(state)
         }
 
-        // read lock acquired - run block
         return try body()
     }
 }

--- a/Tests/ReadWriteLockTests.swift
+++ b/Tests/ReadWriteLockTests.swift
@@ -8,6 +8,9 @@
 
 import XCTest
 import Deferred
+#if SWIFT_PACKAGE
+import AtomicSwift
+#endif
 
 func timeIntervalSleep(duration: NSTimeInterval) {
     usleep(useconds_t(duration * NSTimeInterval(USEC_PER_SEC)))


### PR DESCRIPTION
Working toward #54 by shimming `OSAtomic` when running on not-Darwin using the [AtomicSwift](https://github.com/bignerdranch/AtomicSwift) header. Also adds an extra shim, `_OSAtomicSpin`, to both versions, which allow hyperthreads to continue while livelocking and improve measurable speeds.