### PR TITLE
Lazy map and flatMap

### DIFF
--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -73,6 +73,10 @@
 		DB8710281C758B4500A898FD /* LazyFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710261C758B4500A898FD /* LazyFuture.swift */; };
 		DB8710291C758B4500A898FD /* LazyFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710261C758B4500A898FD /* LazyFuture.swift */; };
 		DB87102A1C758B4500A898FD /* LazyFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710261C758B4500A898FD /* LazyFuture.swift */; };
+		DB8710311C7592F500A898FD /* FutureMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710301C7592F500A898FD /* FutureMap.swift */; };
+		DB8710321C7592F500A898FD /* FutureMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710301C7592F500A898FD /* FutureMap.swift */; };
+		DB8710331C7592F500A898FD /* FutureMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710301C7592F500A898FD /* FutureMap.swift */; };
+		DB8710341C7592F500A898FD /* FutureMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710301C7592F500A898FD /* FutureMap.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -131,6 +135,7 @@
 		DB6AE06E1C237FB200D77BF1 /* LockProtectedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockProtectedTests.swift; sourceTree = "<group>"; };
 		DB6AE06F1C237FB200D77BF1 /* ReadWriteLockTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadWriteLockTests.swift; sourceTree = "<group>"; };
 		DB8710261C758B4500A898FD /* LazyFuture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazyFuture.swift; sourceTree = "<group>"; };
+		DB8710301C7592F500A898FD /* FutureMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureMap.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -220,6 +225,7 @@
 				DB6AE0381C237F8800D77BF1 /* Deferred.swift */,
 				DB6AE0391C237F8800D77BF1 /* ExistentialFuture.swift */,
 				DB6AE03A1C237F8800D77BF1 /* FutureCollections.swift */,
+				DB8710301C7592F500A898FD /* FutureMap.swift */,
 				DB6AE03B1C237F8800D77BF1 /* FutureType.swift */,
 				DB6AE03C1C237F8800D77BF1 /* IgnoringFuture.swift */,
 				DB8710261C758B4500A898FD /* LazyFuture.swift */,
@@ -543,6 +549,7 @@
 				DB6AE05B1C237F8800D77BF1 /* MemoStore.swift in Sources */,
 				DB6AE05F1C237F8800D77BF1 /* PromiseType.swift in Sources */,
 				DB6AE0671C237F8800D77BF1 /* Timeout.swift in Sources */,
+				DB8710321C7592F500A898FD /* FutureMap.swift in Sources */,
 				DB8710281C758B4500A898FD /* LazyFuture.swift in Sources */,
 				DB6AE04B1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
 				DB6AE0471C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
@@ -573,6 +580,7 @@
 				DB6AE05A1C237F8800D77BF1 /* MemoStore.swift in Sources */,
 				DB6AE05E1C237F8800D77BF1 /* PromiseType.swift in Sources */,
 				DB6AE0661C237F8800D77BF1 /* Timeout.swift in Sources */,
+				DB8710311C7592F500A898FD /* FutureMap.swift in Sources */,
 				DB8710271C758B4500A898FD /* LazyFuture.swift in Sources */,
 				DB6AE04A1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
 				DB6AE0461C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
@@ -603,6 +611,7 @@
 				DB6AE05C1C237F8800D77BF1 /* MemoStore.swift in Sources */,
 				DB6AE0601C237F8800D77BF1 /* PromiseType.swift in Sources */,
 				DB6AE0681C237F8800D77BF1 /* Timeout.swift in Sources */,
+				DB8710331C7592F500A898FD /* FutureMap.swift in Sources */,
 				DB8710291C758B4500A898FD /* LazyFuture.swift in Sources */,
 				DB6AE04C1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
 				DB6AE0481C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
@@ -633,6 +642,7 @@
 				DB6AE05D1C237F8800D77BF1 /* MemoStore.swift in Sources */,
 				DB6AE0611C237F8800D77BF1 /* PromiseType.swift in Sources */,
 				DB6AE0691C237F8800D77BF1 /* Timeout.swift in Sources */,
+				DB8710341C7592F500A898FD /* FutureMap.swift in Sources */,
 				DB87102A1C758B4500A898FD /* LazyFuture.swift in Sources */,
 				DB6AE04D1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
 				DB6AE0491C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,

--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -73,6 +73,10 @@
 		DB8710281C758B4500A898FD /* LazyFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710261C758B4500A898FD /* LazyFuture.swift */; };
 		DB8710291C758B4500A898FD /* LazyFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710261C758B4500A898FD /* LazyFuture.swift */; };
 		DB87102A1C758B4500A898FD /* LazyFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710261C758B4500A898FD /* LazyFuture.swift */; };
+		DB87102C1C7592C100A898FD /* FutureFlatMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB87102B1C7592C100A898FD /* FutureFlatMap.swift */; };
+		DB87102D1C7592DC00A898FD /* FutureFlatMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB87102B1C7592C100A898FD /* FutureFlatMap.swift */; };
+		DB87102E1C7592DD00A898FD /* FutureFlatMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB87102B1C7592C100A898FD /* FutureFlatMap.swift */; };
+		DB87102F1C7592DE00A898FD /* FutureFlatMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB87102B1C7592C100A898FD /* FutureFlatMap.swift */; };
 		DB8710311C7592F500A898FD /* FutureMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710301C7592F500A898FD /* FutureMap.swift */; };
 		DB8710321C7592F500A898FD /* FutureMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710301C7592F500A898FD /* FutureMap.swift */; };
 		DB8710331C7592F500A898FD /* FutureMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710301C7592F500A898FD /* FutureMap.swift */; };
@@ -139,6 +143,7 @@
 		DB6AE06E1C237FB200D77BF1 /* LockProtectedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockProtectedTests.swift; sourceTree = "<group>"; };
 		DB6AE06F1C237FB200D77BF1 /* ReadWriteLockTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadWriteLockTests.swift; sourceTree = "<group>"; };
 		DB8710261C758B4500A898FD /* LazyFuture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazyFuture.swift; sourceTree = "<group>"; };
+		DB87102B1C7592C100A898FD /* FutureFlatMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureFlatMap.swift; sourceTree = "<group>"; };
 		DB8710301C7592F500A898FD /* FutureMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureMap.swift; sourceTree = "<group>"; };
 		DBDAC8FD1CAA9E530087EA91 /* FutureFlatten.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureFlatten.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -230,6 +235,8 @@
 				DB6AE0381C237F8800D77BF1 /* Deferred.swift */,
 				DB6AE0391C237F8800D77BF1 /* ExistentialFuture.swift */,
 				DB6AE03A1C237F8800D77BF1 /* FutureCollections.swift */,
+				DBDAC8FD1CAA9E530087EA91 /* FutureFlatten.swift */,
+				DB87102B1C7592C100A898FD /* FutureFlatMap.swift */,
 				DB8710301C7592F500A898FD /* FutureMap.swift */,
 				DB6AE03B1C237F8800D77BF1 /* FutureType.swift */,
 				DB6AE03C1C237F8800D77BF1 /* IgnoringFuture.swift */,
@@ -558,6 +565,7 @@
 				DB8710321C7592F500A898FD /* FutureMap.swift in Sources */,
 				DB8710281C758B4500A898FD /* LazyFuture.swift in Sources */,
 				DB6AE04B1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
+				DB87102D1C7592DC00A898FD /* FutureFlatMap.swift in Sources */,
 				DB6AE0471C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -590,6 +598,7 @@
 				DB8710311C7592F500A898FD /* FutureMap.swift in Sources */,
 				DB8710271C758B4500A898FD /* LazyFuture.swift in Sources */,
 				DB6AE04A1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
+				DB87102C1C7592C100A898FD /* FutureFlatMap.swift in Sources */,
 				DB6AE0461C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -622,6 +631,7 @@
 				DB8710331C7592F500A898FD /* FutureMap.swift in Sources */,
 				DB8710291C758B4500A898FD /* LazyFuture.swift in Sources */,
 				DB6AE04C1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
+				DB87102E1C7592DD00A898FD /* FutureFlatMap.swift in Sources */,
 				DB6AE0481C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -654,6 +664,7 @@
 				DB8710341C7592F500A898FD /* FutureMap.swift in Sources */,
 				DB87102A1C758B4500A898FD /* LazyFuture.swift in Sources */,
 				DB6AE04D1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
+				DB87102F1C7592DE00A898FD /* FutureFlatMap.swift in Sources */,
 				DB6AE0491C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -77,6 +77,10 @@
 		DB8710321C7592F500A898FD /* FutureMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710301C7592F500A898FD /* FutureMap.swift */; };
 		DB8710331C7592F500A898FD /* FutureMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710301C7592F500A898FD /* FutureMap.swift */; };
 		DB8710341C7592F500A898FD /* FutureMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710301C7592F500A898FD /* FutureMap.swift */; };
+		DBDAC8FE1CAA9E530087EA91 /* FutureFlatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDAC8FD1CAA9E530087EA91 /* FutureFlatten.swift */; };
+		DBDAC8FF1CAA9E530087EA91 /* FutureFlatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDAC8FD1CAA9E530087EA91 /* FutureFlatten.swift */; };
+		DBDAC9001CAA9E530087EA91 /* FutureFlatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDAC8FD1CAA9E530087EA91 /* FutureFlatten.swift */; };
+		DBDAC9011CAA9E530087EA91 /* FutureFlatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDAC8FD1CAA9E530087EA91 /* FutureFlatten.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -136,6 +140,7 @@
 		DB6AE06F1C237FB200D77BF1 /* ReadWriteLockTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadWriteLockTests.swift; sourceTree = "<group>"; };
 		DB8710261C758B4500A898FD /* LazyFuture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazyFuture.swift; sourceTree = "<group>"; };
 		DB8710301C7592F500A898FD /* FutureMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureMap.swift; sourceTree = "<group>"; };
+		DBDAC8FD1CAA9E530087EA91 /* FutureFlatten.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureFlatten.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -544,6 +549,7 @@
 				DB6AE04F1C237F8800D77BF1 /* FutureType.swift in Sources */,
 				DB6AE0531C237F8800D77BF1 /* IgnoringFuture.swift in Sources */,
 				DB6AE0431C237F8800D77BF1 /* Deferred.swift in Sources */,
+				DBDAC8FF1CAA9E530087EA91 /* FutureFlatten.swift in Sources */,
 				DB6AE0631C237F8800D77BF1 /* ReadWriteLock.swift in Sources */,
 				DB6AE0571C237F8800D77BF1 /* LockProtected.swift in Sources */,
 				DB6AE05B1C237F8800D77BF1 /* MemoStore.swift in Sources */,
@@ -575,6 +581,7 @@
 				DB6AE04E1C237F8800D77BF1 /* FutureType.swift in Sources */,
 				DB6AE0521C237F8800D77BF1 /* IgnoringFuture.swift in Sources */,
 				DB6AE0421C237F8800D77BF1 /* Deferred.swift in Sources */,
+				DBDAC8FE1CAA9E530087EA91 /* FutureFlatten.swift in Sources */,
 				DB6AE0621C237F8800D77BF1 /* ReadWriteLock.swift in Sources */,
 				DB6AE0561C237F8800D77BF1 /* LockProtected.swift in Sources */,
 				DB6AE05A1C237F8800D77BF1 /* MemoStore.swift in Sources */,
@@ -606,6 +613,7 @@
 				DB6AE0501C237F8800D77BF1 /* FutureType.swift in Sources */,
 				DB6AE0541C237F8800D77BF1 /* IgnoringFuture.swift in Sources */,
 				DB6AE0441C237F8800D77BF1 /* Deferred.swift in Sources */,
+				DBDAC9001CAA9E530087EA91 /* FutureFlatten.swift in Sources */,
 				DB6AE0641C237F8800D77BF1 /* ReadWriteLock.swift in Sources */,
 				DB6AE0581C237F8800D77BF1 /* LockProtected.swift in Sources */,
 				DB6AE05C1C237F8800D77BF1 /* MemoStore.swift in Sources */,
@@ -637,6 +645,7 @@
 				DB6AE0511C237F8800D77BF1 /* FutureType.swift in Sources */,
 				DB6AE0551C237F8800D77BF1 /* IgnoringFuture.swift in Sources */,
 				DB6AE0451C237F8800D77BF1 /* Deferred.swift in Sources */,
+				DBDAC9011CAA9E530087EA91 /* FutureFlatten.swift in Sources */,
 				DB6AE0651C237F8800D77BF1 /* ReadWriteLock.swift in Sources */,
 				DB6AE0591C237F8800D77BF1 /* LockProtected.swift in Sources */,
 				DB6AE05D1C237F8800D77BF1 /* MemoStore.swift in Sources */,

--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -69,6 +69,10 @@
 		DB6AE07C1C237FB900D77BF1 /* Deferred.h in Headers */ = {isa = PBXBuildFile; fileRef = DB6ADFD61C237DD500D77BF1 /* Deferred.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB6AE07D1C237FBC00D77BF1 /* Deferred.h in Headers */ = {isa = PBXBuildFile; fileRef = DB6ADFD61C237DD500D77BF1 /* Deferred.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB6AE07E1C237FBE00D77BF1 /* Deferred.h in Headers */ = {isa = PBXBuildFile; fileRef = DB6ADFD61C237DD500D77BF1 /* Deferred.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DB8710271C758B4500A898FD /* LazyFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710261C758B4500A898FD /* LazyFuture.swift */; };
+		DB8710281C758B4500A898FD /* LazyFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710261C758B4500A898FD /* LazyFuture.swift */; };
+		DB8710291C758B4500A898FD /* LazyFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710261C758B4500A898FD /* LazyFuture.swift */; };
+		DB87102A1C758B4500A898FD /* LazyFuture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8710261C758B4500A898FD /* LazyFuture.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -126,6 +130,7 @@
 		DB6AE06D1C237FB200D77BF1 /* IgnoringFutureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IgnoringFutureTests.swift; sourceTree = "<group>"; };
 		DB6AE06E1C237FB200D77BF1 /* LockProtectedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockProtectedTests.swift; sourceTree = "<group>"; };
 		DB6AE06F1C237FB200D77BF1 /* ReadWriteLockTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadWriteLockTests.swift; sourceTree = "<group>"; };
+		DB8710261C758B4500A898FD /* LazyFuture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazyFuture.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -217,6 +222,7 @@
 				DB6AE03A1C237F8800D77BF1 /* FutureCollections.swift */,
 				DB6AE03B1C237F8800D77BF1 /* FutureType.swift */,
 				DB6AE03C1C237F8800D77BF1 /* IgnoringFuture.swift */,
+				DB8710261C758B4500A898FD /* LazyFuture.swift */,
 				DB6AE03D1C237F8800D77BF1 /* LockProtected.swift */,
 				DB6AE03E1C237F8800D77BF1 /* MemoStore.swift */,
 				DB6AE03F1C237F8800D77BF1 /* PromiseType.swift */,
@@ -537,6 +543,7 @@
 				DB6AE05B1C237F8800D77BF1 /* MemoStore.swift in Sources */,
 				DB6AE05F1C237F8800D77BF1 /* PromiseType.swift in Sources */,
 				DB6AE0671C237F8800D77BF1 /* Timeout.swift in Sources */,
+				DB8710281C758B4500A898FD /* LazyFuture.swift in Sources */,
 				DB6AE04B1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
 				DB6AE0471C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
 			);
@@ -566,6 +573,7 @@
 				DB6AE05A1C237F8800D77BF1 /* MemoStore.swift in Sources */,
 				DB6AE05E1C237F8800D77BF1 /* PromiseType.swift in Sources */,
 				DB6AE0661C237F8800D77BF1 /* Timeout.swift in Sources */,
+				DB8710271C758B4500A898FD /* LazyFuture.swift in Sources */,
 				DB6AE04A1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
 				DB6AE0461C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
 			);
@@ -595,6 +603,7 @@
 				DB6AE05C1C237F8800D77BF1 /* MemoStore.swift in Sources */,
 				DB6AE0601C237F8800D77BF1 /* PromiseType.swift in Sources */,
 				DB6AE0681C237F8800D77BF1 /* Timeout.swift in Sources */,
+				DB8710291C758B4500A898FD /* LazyFuture.swift in Sources */,
 				DB6AE04C1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
 				DB6AE0481C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
 			);
@@ -624,6 +633,7 @@
 				DB6AE05D1C237F8800D77BF1 /* MemoStore.swift in Sources */,
 				DB6AE0611C237F8800D77BF1 /* PromiseType.swift in Sources */,
 				DB6AE0691C237F8800D77BF1 /* Timeout.swift in Sources */,
+				DB87102A1C758B4500A898FD /* LazyFuture.swift in Sources */,
 				DB6AE04D1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
 				DB6AE0491C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
 			);

--- a/Sources/FutureFlatMap.swift
+++ b/Sources/FutureFlatMap.swift
@@ -1,0 +1,77 @@
+//
+//  FutureFlatMap.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 2/17/16.
+//  Copyright © 2016 Big Nerd Ranch. All rights reserved.
+//
+
+import Dispatch
+
+extension LazyFutureType where Value == UnderlyingFuture.Value {
+
+    /// Returns a combined view of a future that begins another asynchronous
+    /// operation with the result of some first operation.
+    ///
+    /// The second operation is not created if the result is never used.
+    public func flatMap<NewFuture: FutureType>(transform: Value -> NewFuture) -> LazyFuture<FlattenFuture<LazyMapFuture<UnderlyingFuture, NewFuture>>> {
+        return map(transform).flatten()
+    }
+
+}
+
+extension LazyFutureType {
+
+    /// Returns a combined view of a future that begins another asynchronous
+    /// operation with the result of some first operation.
+    ///
+    /// The second operation is not created if the result is never used.
+    public func flatMap<NewFuture: FutureType>(transform: Value -> NewFuture) -> LazyFuture<FlattenFuture<LazyMapFuture<Self, NewFuture>>> {
+        return map(transform).flatten()
+    }
+    
+}
+
+extension FutureType {
+
+    /// Begins another asynchronous operation with this delayed value, once it
+    /// becomes determined.
+    ///
+    /// The new future is created on a on a global queue matching the current
+    /// quality-of-service.
+    ///
+    /// - parameter transform: Begin a new operation using the deferred value.
+    /// - returns: A new deferred value as returned by the `transform`.
+    /// - seealso: flatMap(upon:_:)
+    public func flatMap<NewFuture: FutureType>(transform: Value -> NewFuture) -> Future<NewFuture.Value> {
+        return flatMap(upon: Self.genericQueue, transform)
+    }
+
+    /// Begins another asynchronous operation with this delayed value, once it
+    /// becomes determined.
+    ///
+    /// `flatMap` is similar to `map`; use `flatMap` when you want this delayed
+    /// value to feed into another asynchronous operation. You might hear this
+    /// referred to as "chaining" or "binding".
+    ///
+    /// - important: The new future is created on another queue than that of the
+    ///   caller. Keep this in mind for multithreading; a user of the determined
+    ///   value might expect to be called from a certain queue.
+    ///
+    /// Equivalent to `map(transform).flatten()`, but more efficient.
+    ///
+    /// - parameter queue: Optional dispatch queue for starting the new
+    ///   operation from.
+    /// - parameter transform: Begin a new operation using the deferred value.
+    /// - returns: A new deferred value as returned by the `transform`.
+    /// - seealso: flatten()
+    public func flatMap<NewFuture: FutureType>(upon queue: dispatch_queue_t, _ transform: Value -> NewFuture) -> Future<NewFuture.Value> {
+        let d = Deferred<NewFuture.Value>()
+        let mapped = lazy.map(transform).flatten()
+        mapped.upon(queue) {
+            d.fill($0)
+        }
+        return .init(d)
+    }
+
+}

--- a/Sources/FutureFlatten.swift
+++ b/Sources/FutureFlatten.swift
@@ -1,0 +1,86 @@
+//
+//  FutureFlatten.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 2/17/16.
+//  Copyright © 2016 Big Nerd Ranch. All rights reserved.
+//
+
+import Dispatch
+
+/// A combined view of a future that contains another future.
+///
+/// The determined value of this future is that of the innermost future when
+/// both inner and outer futures are determined.
+///
+/// - note: To `flatten` itself is always lazy, but does not imply laziness
+/// on algorithms applied to the result.  In other words:
+/// * `future.flatten()` does not perform any operations
+/// * `future.flatten().map(upon:_:)` maps eagerly, returning `Future`
+/// * `future.lazy.flatten().map(_:)` maps lazily
+public struct FlattenFuture<Base: FutureType where Base.Value: FutureType>: FutureType {
+
+    private let base: Base
+    private init(base: Base) {
+        self.base = base
+    }
+
+    /// Call some function `body` once the inner and outer values become
+    /// determined.
+    ///
+    /// If the innermost value is determined, the function will be submitted to
+    /// the queue immediately. An upon call is always executed asynchronously.
+    ///
+    /// - parameter queue: A dispatch queue to execute the function `body` on.
+    /// - parameter body: A function that uses the innermost delayed value.
+    public func upon(queue: dispatch_queue_t, body: Base.Value.Value -> Void) {
+        base.upon(queue) {
+            $0.upon(queue, body: body)
+        }
+    }
+
+    /// Waits synchronously, for a maximum `time`, for the innermost value to
+    /// become available; otherwise, returns `nil`.
+    public func wait(time: Timeout) -> Base.Value.Value? {
+        return base.wait(.Now)?.wait(time)
+    }
+
+}
+
+// Note: This may look like a duplicate method, but this directly shadows the
+// eager "map" on FutureType, breaking what is otherwise an ambiguity.
+extension LazyFutureType where Value: FutureType, Value == UnderlyingFuture.Value {
+
+    /// A combined view of a lazy future that contains another future.
+    ///
+    /// - seealso: flatMap(_:)
+    public func flatten() -> LazyFuture<FlattenFuture<UnderlyingFuture>> {
+        return FlattenFuture(base: underlyingFuture).lazy
+    }
+
+}
+
+extension LazyFutureType where Value: FutureType {
+
+    /// A combined view of a lazy future that contains another future.
+    ///
+    /// - seealso: flatMap(_:)
+    public func flatten() -> LazyFuture<FlattenFuture<Self>> {
+        return FlattenFuture(base: self).lazy
+    }
+
+}
+
+extension FutureType where Value: FutureType {
+
+    /// A combined future that is determined with the value of the innermost
+    /// future when both inner and outer futures are determined.
+    ///
+    /// - returns: The new future returned by combining these nested futures.
+    /// - seealso: FutureType.Type.genericQueue
+    /// - seealso: flatMap(_:)
+    public func flatten() -> Future<Value.Value> {
+        return Future(lazy.flatten())
+    }
+
+}

--- a/Sources/FutureFlatten.swift
+++ b/Sources/FutureFlatten.swift
@@ -34,8 +34,12 @@ public struct FlattenFuture<Base: FutureType where Base.Value: FutureType>: Futu
     /// - parameter queue: A dispatch queue to execute the function `body` on.
     /// - parameter body: A function that uses the innermost delayed value.
     public func upon(queue: dispatch_queue_t, body: Base.Value.Value -> Void) {
-        base.upon(queue) {
-            $0.upon(queue, body: body)
+        if let nested = base.peek() {
+            nested.upon(queue, body: body)
+        } else {
+            base.upon(queue) {
+                $0.upon(queue, body: body)
+            }
         }
     }
 

--- a/Sources/FutureMap.swift
+++ b/Sources/FutureMap.swift
@@ -1,0 +1,93 @@
+//
+//  LazyMapFuture.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 2/17/16.
+//  Copyright © 2016 Big Nerd Ranch. Licensed under MIT.
+//
+
+import Dispatch
+
+/// A `FutureType` whose determined element is that of a `Base` future passed
+/// through a transform function returning `NewValue`. This value is computed
+/// each time it is read through a call to `upon(queue:body:)`.
+public struct LazyMapFuture<Base: FutureType, NewValue>: LazyFutureType {
+
+    private let base: Base
+    private let transform: Base.Value -> NewValue
+    private init(_ base: Base, transform: Base.Value -> NewValue) {
+        self.base = base
+        self.transform = transform
+    }
+
+    /// Call some function `body` once the value becomes determined.
+    ///
+    /// If the value is determined, the function will be submitted to the
+    /// queue immediately. An upon call is always executed asynchronously.
+    ///
+    /// - parameter queue: A dispatch queue to execute the function `body` on.
+    /// - parameter body: A function that uses the delayed value.
+    public func upon(queue: dispatch_queue_t, body: NewValue -> Void) {
+        return base.upon(queue) { [transform] in
+            body(transform($0))
+        }
+    }
+
+    /// Waits synchronously, for a maximum `time`, for the calculated value to
+    /// become determined; otherwise, returns `nil`.
+    public func wait(time: Timeout) -> NewValue? {
+        return base.wait(time).map(transform)
+    }
+
+}
+
+// Note: This may look like a duplicate method, but this directly shadows the
+// eager "map" on FutureType, breaking what is otherwise an ambiguity.
+extension LazyFutureType where Value == UnderlyingFuture.Value {
+
+    /// Returns a `LazyMapFuture` over this `FutureType`. The value of the result
+    /// is determined lazily, each time it is read, by calling a `transform` on
+    /// the base value.
+    public func map<NewValue>(transform: Value -> NewValue) -> LazyMapFuture<UnderlyingFuture, NewValue> {
+        return .init(underlyingFuture, transform: transform)
+    }
+
+}
+
+extension LazyFutureType {
+
+    /// Returns a `LazyMapFuture` over this `FutureType`. The value of the result
+    /// is determined lazily, each time it is read, by calling a `transform` on
+    /// the base value.
+    public func map<NewValue>(transform: Value -> NewValue) -> LazyMapFuture<Self, NewValue> {
+        return .init(self, transform: transform)
+    }
+
+}
+
+extension FutureType {
+
+    /// Transforms the future once it becomes determined. The calculation is
+    /// performed on a global queue matching the current quality-of-service.
+    ///
+    /// - parameter transform: Create something using the determined value.
+    /// - returns: A new future that is filled after this one is determined.
+    /// - seealso: map(upon:_:)
+    public func map<NewValue>(transform: Value -> NewValue) -> Future<NewValue> {
+        return map(upon: Self.genericQueue, transform)
+    }
+
+    /// Transforms the future once it becomes determined.
+    ///
+    /// - parameter queue: Dispatch queue for executing the transform from.
+    /// - parameter transform: Create something using the determined value.
+    /// - returns: A new future that is filled after this one is determined.
+    public func map<NewValue>(upon queue: dispatch_queue_t, _ transform: Value -> NewValue) -> Future<NewValue> {
+        let d = Deferred<NewValue>()
+        lazy.map(transform).upon(queue) {
+            d.fill($0)
+        }
+        return Future(d)
+    }
+
+}

--- a/Sources/FutureType.swift
+++ b/Sources/FutureType.swift
@@ -140,24 +140,6 @@ extension FutureType {
         }
         return Future(d)
     }
-
-    /// Transforms the future once it becomes determined.
-    ///
-    /// `map` executes a transform immediately when the future's value is
-    /// determined.
-    ///
-    /// - parameter queue: Optional dispatch queue for executing the transform
-    ///   from. Defaults to a global queue matching the current QoS.
-    /// - parameter transform: Create something using the deferred value.
-    /// - returns: A new future that is filled once the reciever is determined.
-    /// - seealso: Deferred
-    public func map<NewValue>(upon queue: dispatch_queue_t = Self.genericQueue, _ transform: Value -> NewValue) -> Future<NewValue> {
-        let d = Deferred<NewValue>()
-        upon(queue) {
-            d.fill(transform($0))
-        }
-        return Future(d)
-    }
 }
 
 extension FutureType {

--- a/Sources/FutureType.swift
+++ b/Sources/FutureType.swift
@@ -118,31 +118,6 @@ extension FutureType {
 }
 
 extension FutureType {
-    /// Begins another asynchronous operation with the deferred value once it
-    /// becomes determined.
-    ///
-    /// `flatMap` is similar to `map`, but `transform` returns a `Deferred`
-    /// instead of an immediate value. Use `flatMap` when you want this future
-    /// to feed into another asynchronous operation. You might hear this
-    /// referred to as "chaining" or "binding".
-    ///
-    /// - parameter queue: Optional dispatch queue for starting the new
-    ///   operation from. Defaults to a global queue matching the current QoS.
-    /// - parameter transform: Start a new operation using the deferred value.
-    /// - returns: The new deferred value returned by the `transform`.
-    /// - seealso: Deferred
-    public func flatMap<NewFuture: FutureType>(upon queue: dispatch_queue_t = Self.genericQueue, _ transform: Value -> NewFuture) -> Future<NewFuture.Value> {
-        let d = Deferred<NewFuture.Value>()
-        upon(queue) {
-            transform($0).upon(queue) {
-                d.fill($0)
-            }
-        }
-        return Future(d)
-    }
-}
-
-extension FutureType {
     /// Composes this future with another.
     ///
     /// - parameter other: Any other future.

--- a/Sources/LazyFuture.swift
+++ b/Sources/LazyFuture.swift
@@ -1,0 +1,110 @@
+//
+//  LazyFuture.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 2/17/16.
+//  Copyright © 2016 Big Nerd Ranch. Licensed under MIT.
+//
+
+import Dispatch
+
+/// A wrapped future on which normally-eager operations such as `map` are
+/// implemented lazily.
+///
+/// Lazy futures can be used to avoid needless creation of `Deferred` to reflect
+/// a simple computation, because they wrap another future and perform
+/// calculations on demand. For example,
+///
+///     someIntDeferred.lazy.map { Double($0 * 2) }
+///
+/// is now a `FutureType` eventually resolving to a doubled `Double`. Each
+/// `upon` or `wait` is transformed on-the-fly.
+///
+/// To create a lazy future operation, extend this protocol to return types
+/// that are themselves lazy futures.
+///
+/// - seealso: LazyFuture
+public protocol LazyFutureType: FutureType {
+
+    /// A `FutureType` that will resolve to the same `Value` as `self`,
+    /// hopefully with a simpler type.
+    ///
+    /// - seealso: underlyingFuture
+    associatedtype UnderlyingFuture: FutureType = Self
+
+    /// A future resolving to the same value as `self`, hopefully with a simpler
+    /// type.
+    ///
+    /// By default, returns `self`.
+    var underlyingFuture: UnderlyingFuture { get }
+
+}
+
+extension LazyFutureType where UnderlyingFuture == Self {
+
+    /// Identical to `self`.
+    public var underlyingFuture: Self {
+        return self
+    }
+
+}
+
+extension FutureType where Self: LazyFutureType, Self.Value == Self.UnderlyingFuture.Value {
+
+    /// Call some function `body` once the value becomes determined.
+    ///
+    /// If the value is determined, the function will be submitted to the
+    /// queue immediately. An upon call is always executed asynchronously.
+    ///
+    /// - parameter queue: A dispatch queue to execute the function `body` on.
+    /// - parameter body: A function that uses the determined value.
+    public func upon(queue: dispatch_queue_t, body: Value -> Void) {
+        return underlyingFuture.upon(queue, body: body)
+    }
+
+    /// Waits synchronously, for a maximum `time`, for the value to become
+    /// determined; otherwise, returns `nil`.
+    public func wait(time: Timeout) -> Value? {
+        return underlyingFuture.wait(time)
+    }
+
+}
+
+/// A future resolving to the same `Value` as a `Base` future, but on which
+/// some operations should be implemented lazily.
+///
+/// - seealso: LazyFutureType
+public struct LazyFuture<Base: FutureType>: LazyFutureType {
+
+    public typealias Value = Base.Value
+
+    /// The wrapped future.
+    public let underlyingFuture: Base
+
+    /// Creates a future that wraps `base`.
+    private init(base underlyingFuture: Base) {
+        self.underlyingFuture = underlyingFuture
+    }
+
+}
+
+extension FutureType {
+
+    /// A future resolving to the same `Value` as this one, but on which some
+    /// operations can be done lazily.
+    ///
+    /// - seealso: LazyFuture
+    public var lazy: LazyFuture<Self> {
+        return .init(base: self)
+    }
+
+}
+
+extension LazyFutureType {
+
+    /// Identical to `self`.
+    public var lazy: Self {
+        return self
+    }
+
+}

--- a/Tests/IgnoringFutureTests.swift
+++ b/Tests/IgnoringFutureTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class IgnoringFutureTests: XCTestCase {
 
-    var future: IgnoringFuture<Deferred<Int>>!
+    var future: Future<Void>!
 
     override func tearDown() {
         future = nil
@@ -21,7 +21,7 @@ class IgnoringFutureTests: XCTestCase {
 
     func testWaitWithTimeout() {
         let deferred = Deferred<Int>()
-        future = IgnoringFuture(deferred)
+        future = deferred.ignore()
 
         let expect = expectationWithDescription("value blocks while unfilled")
         after(1, upon: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
@@ -37,7 +37,7 @@ class IgnoringFutureTests: XCTestCase {
 
     func testIgnoredUponCalledWhenFilled() {
         let d = Deferred<Int>()
-        future = IgnoringFuture(d)
+        future = d.ignore()
 
         for _ in 0 ..< 10 {
             let expect = expectationWithDescription("upon blocks not called while deferred is unfilled")


### PR DESCRIPTION
#### What's in this pull request?

* Adds a `lazy` subtree of types, derived from Swift's `LazyCollectionType`, on which `map` and `flatMap` can be modeled lazily.
  - `lazy.map(_:)` executes the transform on each call to `upon` or `lazy`. This is a semantics and performance improvement for simple conversions.
  - `lazy.flatMap(_:)` defers the start of the new operation until a call to `upon` or `lazy` is made.
  - The types introduced will reduce code duplication needed in #64.
* Introduces a `flatten()` method (incl. a lazy definition) for combining two `Future`s, if you are ever so unfortunate as to get one of those.
* Introduces a `ignore()` method to replace `IgnoringFuture`.

* [ ] Might be able to wrangle a performance improvement from `and` by `lazy.map`-ing to `Any` and using `joinedValues`. Need to do tests; should attach to a separate issue.

#### Testing

* [ ] Add tests for the new guarantees made by `lazy`.

#### API Changes

The `lazy` constructs are additive. The little-used `IgnoringFuture` type is replaced by the new lazy getters. Though `IgnoringFuture` is removed, its symbol remains with migration guidance.

`IgnoringFuture` would be removed in the final release of 2.0.