### PR TITLE
Re-adopt Scan for Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 ## Build generated
-.build/
 build/
-DerivedData
-docs/
-Packages/
+DerivedData/
 
 ## Various settings
 *.pbxuser
@@ -17,11 +14,16 @@ Packages/
 xcuserdata
 
 ## Other
-*.xccheckout
 *.moved-aside
-*.xcuserstate
+*.xccheckout
 *.xcscmblueprint
 
+# Swift Package Manager
+Packages/
+.build/
+
+# Jazzy
+docs/
 
 # Fastlane/Scan
 test_output/

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,6 @@ xcuserdata
 *.xcuserstate
 *.xcscmblueprint
 
-## Obj-C/Swift specific
-*.hmap
-*.ipa
+
+# Fastlane/Scan
+test_output/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
 language: objective-c
 osx_image: xcode7.2
 install:
-- gem install xcpretty --no-rdoc --no-ri --no-document
+- gem install scan --no-rdoc --no-ri --no-document
 - gem install cocoapods --no-rdoc --no-ri --no-document
 - gem install jazzy --no-rdoc --no-ri --no-document
 - curl -OlL "https://github.com/Carthage/Carthage/releases/download/0.11/Carthage.pkg"
 - sudo installer -pkg "Carthage.pkg" -target /
 - rm "Carthage.pkg"
+env:
+- SCAN_OPEN_REPORT=false
+before_script:
+- set -o pipefail
 script:
-- open -b com.apple.iphonesimulator
-- set -o pipefail && xcodebuild test -scheme 'Deferred' -sdk macosx | xcpretty -c
-- set -o pipefail && xcodebuild test -scheme 'MobileDeferred' -sdk iphonesimulator
-  -destination 'platform=iOS Simulator,name=iPhone 5' | xcpretty -c
-- set -o pipefail && xcodebuild test -scheme 'TVDeferred' -sdk appletvsimulator -destination
-  'platform=tvOS Simulator,name=Apple TV 1080p' | xcpretty -c
-- carthage build --no-skip-current
+- scan -s Deferred
+- scan -s MobileDeferred
+- scan -s TVDeferred
+- carthage build --no-skip-current --configuration Debug
 - pod lib lint --quick
 after_success:
 - "./Configurations/publish_docs.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: objective-c
 osx_image: xcode7.2
 install:
-- gem install scan --no-rdoc --no-ri --no-document
-- gem install cocoapods --no-rdoc --no-ri --no-document
-- gem install jazzy --no-rdoc --no-ri --no-document
-- curl -OlL "https://github.com/Carthage/Carthage/releases/download/0.11/Carthage.pkg"
-- sudo installer -pkg "Carthage.pkg" -target /
-- rm "Carthage.pkg"
+- gem install scan --no-rdoc --no-ri --no-document --quiet
+- gem install cocoapods --no-rdoc --no-ri --no-document --quiet
+- gem install jazzy --no-rdoc --no-ri --no-document --quiet
+- brew install carthage --force-bottle
 env:
 - SCAN_OPEN_REPORT=false
 before_script:


### PR DESCRIPTION
Since fastlane/scan#5, we could again use `scan` to drive CI. The changes involved make CI a solid minute faster. Not entirely sure of the other tradeoffs, but I wrote the config changes anyway to test that fastlane/scan#5 was fixed, so might as well get some :eyes:.

- [Output example](https://travis-ci.org/zwaldowski/Deferred/builds/111130027)
- ["Why `scan`?"](https://github.com/fastlane/scan#why-scan)