### PR TITLE
Improve debugging through reflection support

### DIFF
--- a/Sources/ExistentialFuture.swift
+++ b/Sources/ExistentialFuture.swift
@@ -106,4 +106,9 @@ public struct Future<Value>: FutureType {
     public func wait(time: Timeout) -> Value? {
         return box.wait(time)
     }
+
+    /// Return the `Mirror` for `self`.
+    public func customMirror() -> Mirror {
+        return Mirror(reflecting: box)
+    }
 }

--- a/Sources/FutureType.swift
+++ b/Sources/FutureType.swift
@@ -198,24 +198,14 @@ public extension FutureType {
     }
 }
 
-// This is just to get us the syntax-highlighted "(not filled)" in playgrounds.
-private struct NotFilledMarker: CustomDebugStringConvertible {
-
-    static func mirrorFor<T>(subject: T) -> Mirror {
-        return Mirror(subject, unlabeledChildren: CollectionOfOne(NotFilledMarker()), displayStyle: .Tuple)
-    }
-
-    var debugDescription: String {
-        return "not filled"
-    }
-}
-
 extension FutureType {
 
     /// A textual representation of `self`, suitable for debugging.
     public var debugDescription: String {
         var ret = "\(Self.self)"
-        if let value = peek() {
+        if Value.self == Void.self && isFilled {
+            ret += " (filled)"
+        } else if let value = peek() {
             ret += "(\(String(reflecting: value)))"
         } else {
             ret += " (not filled)"
@@ -225,9 +215,11 @@ extension FutureType {
 
     /// Return the `Mirror` for `self`.
     public func customMirror() -> Mirror {
-        return peek().map {
-            Mirror(self, children: [ "value": $0 ], displayStyle: .Optional)
-        } ?? NotFilledMarker.mirrorFor(self)
+        if Value.self != Void.self, let value = peek() {
+            return Mirror(self, children: [ "value": value ], displayStyle: .Optional)
+        } else {
+            return Mirror(self, children: [ "isFilled": isFilled ], displayStyle: .Tuple)
+        }
     }
 
 }

--- a/Sources/LockProtected.swift
+++ b/Sources/LockProtected.swift
@@ -42,4 +42,21 @@ public final class LockProtected<T> {
             try body(&self.item)
         }
     }
+
+    private var synchronizedValue: T? {
+        return lock.withAttemptedReadLock { self.item }
+    }
+}
+
+extension LockProtected: CustomDebugStringConvertible {
+
+    /// A textual representation of `self`, suitable for debugging.
+    public var debugDescription: String {
+        if let value = synchronizedValue {
+            return "LockProtected(\(String(reflecting: value)))"
+        } else {
+            return "\(self.dynamicType) (lock contended)"
+        }
+    }
+    
 }


### PR DESCRIPTION
This achieves two primary benefits:

* Futures (i.e., `Deferred`) and `LockProtected` have sidebar results in playgrounds through `Mirror`.
* Futures (i.e., `Deferred`, and notably `Future<T>`) and `LockProtected` have better results in the debugger through `debugDescription`.
   - Though Swift has fallback behavior to recover, we have `debugDescription` but not `description` because these descriptions are not intended to be user-facing at any point.


## API Changes

Purely additive. `FutureType` gains inheritance of Swift's reflection protocols, but provides default implementations.