### PR TITLE
Expose FutureType.genericQueue as public API

### DIFF
--- a/Sources/FutureCollections.swift
+++ b/Sources/FutureCollections.swift
@@ -45,7 +45,7 @@ public extension CollectionType where Generator.Element: FutureType {
             }
         }
 
-        dispatch_group_notify(group, genericQueue) {
+        dispatch_group_notify(group, Generator.Element.genericQueue) {
             combined.fill(array.map {
                 $0.value
             })


### PR DESCRIPTION
This PR makes its way out of a change made independently in #75 and the WIP branch for #64: to re-use the guarantees made for the `genericQueue` constant outside the `Deferred` module, it must be made public.

## API Changes

Purely additive.