### PR TITLE
Fix "LockProtected" type showing up in playgrounds

### DIFF
--- a/Sources/LockProtected.swift
+++ b/Sources/LockProtected.swift
@@ -48,7 +48,7 @@ public final class LockProtected<T> {
     }
 }
 
-extension LockProtected: CustomDebugStringConvertible {
+extension LockProtected: CustomDebugStringConvertible, CustomReflectable {
 
     /// A textual representation of `self`, suitable for debugging.
     public var debugDescription: String {
@@ -58,5 +58,13 @@ extension LockProtected: CustomDebugStringConvertible {
             return "\(self.dynamicType) (lock contended)"
         }
     }
-    
+
+    public func customMirror() -> Mirror {
+        if let value = synchronizedValue {
+            return Mirror(self, children: [ "item": value ], displayStyle: .Optional)
+        } else {
+            return Mirror(self, children: [ "lockContended": true ], displayStyle: .Tuple)
+        }
+    }
+
 }


### PR DESCRIPTION
Thanks, @cbkeur!

#### What's in this pull request?

Fixes an issue introduced in #80. `Mirror`s should give fluent values when used in a playground, ideally without type names unless they're user-created. For `Future`s, this means printing just the value in the playground sidebar — `LockProtected` should do the same.

#80 avoided implementing `LockProtected.customMirror()` out of convenience, but doesn't have the behavior we want.

#### Testing

To be improved in a future PR. Swift documentation suggests `Mirror` contents shouldn't be relied upon, but we can write tests against it anyway.

#### API Changes

Adds a `Mirror` conformance for `LockProtected`, meaning there is now a structured view of `LockProtected`'s contents, vs. the one generated by the compiler.
