### PR TITLE
Slight cleanup to access control in FutureType extensions

### DIFF
--- a/Sources/FutureCollections.swift
+++ b/Sources/FutureCollections.swift
@@ -8,12 +8,12 @@
 
 import Dispatch
 
-public extension SequenceType where Generator.Element: FutureType {
+extension SequenceType where Generator.Element: FutureType {
     /// Choose the future that is determined first from a collection of futures.
     ///
     /// - returns: A deferred value that is determined with the first of the
     ///   given futures to be determined.
-    var earliestFilled: Future<Generator.Element.Value> {
+    public var earliestFilled: Future<Generator.Element.Value> {
         let combined = Deferred<Generator.Element.Value>()
         for future in self {
             future.upon {
@@ -24,12 +24,12 @@ public extension SequenceType where Generator.Element: FutureType {
     }
 }
 
-public extension CollectionType where Generator.Element: FutureType {
+extension CollectionType where Generator.Element: FutureType {
     /// Compose a number of futures into a single deferred array.
     ///
     /// - returns: A deferred array that is determined once all the given values
     ///   are determined, in the same order.
-    var joinedValues: Future<[Generator.Element.Value]> {
+    public var joinedValues: Future<[Generator.Element.Value]> {
         if isEmpty {
             return Future(value: [])
         }

--- a/Sources/FutureType.swift
+++ b/Sources/FutureType.swift
@@ -67,14 +67,14 @@ extension FutureType {
     }
 }
 
-public extension FutureType {
+extension FutureType {
     /// Call some function in the background once the value is determined.
     ///
     /// If the value is determined, the function will be dispatched immediately.
     /// An `upon` call should always execute asynchronously.
     ///
     /// - parameter body: A function that uses the determined value.
-    func upon(body: Value -> ()) {
+    public func upon(body: Value -> ()) {
         upon(Self.genericQueue, body: body)
     }
 
@@ -85,16 +85,16 @@ public extension FutureType {
     /// asynchronously, even if this function is called from the main queue.
     ///
     /// - parameter body: A function that uses the determined value.
-    func uponMainQueue(body: Value -> ()) {
+    public func uponMainQueue(body: Value -> ()) {
         upon(dispatch_get_main_queue(), body: body)
     }
 }
 
-public extension FutureType {
+extension FutureType {
     /// Checks for and returns a determined value.
     ///
     /// - returns: The determined value, if already filled, or `nil`.
-    func peek() -> Value? {
+    public func peek() -> Value? {
         return wait(.Now)
     }
 
@@ -107,17 +107,17 @@ public extension FutureType {
     /// testing, but otherwise it should be strictly avoided.
     ///
     /// - returns: The determined value.
-    internal var value: Value {
+    var value: Value {
         return wait(.Forever)!
     }
 
     /// Check whether or not the receiver is filled.
-    internal var isFilled: Bool {
+    var isFilled: Bool {
         return wait(.Now) != nil
     }
 }
 
-public extension FutureType {
+extension FutureType {
     /// Begins another asynchronous operation with the deferred value once it
     /// becomes determined.
     ///
@@ -131,7 +131,7 @@ public extension FutureType {
     /// - parameter transform: Start a new operation using the deferred value.
     /// - returns: The new deferred value returned by the `transform`.
     /// - seealso: Deferred
-    func flatMap<NewFuture: FutureType>(upon queue: dispatch_queue_t = Self.genericQueue, _ transform: Value -> NewFuture) -> Future<NewFuture.Value> {
+    public func flatMap<NewFuture: FutureType>(upon queue: dispatch_queue_t = Self.genericQueue, _ transform: Value -> NewFuture) -> Future<NewFuture.Value> {
         let d = Deferred<NewFuture.Value>()
         upon(queue) {
             transform($0).upon(queue) {
@@ -151,7 +151,7 @@ public extension FutureType {
     /// - parameter transform: Create something using the deferred value.
     /// - returns: A new future that is filled once the reciever is determined.
     /// - seealso: Deferred
-    func map<NewValue>(upon queue: dispatch_queue_t = Self.genericQueue, _ transform: Value -> NewValue) -> Future<NewValue> {
+    public func map<NewValue>(upon queue: dispatch_queue_t = Self.genericQueue, _ transform: Value -> NewValue) -> Future<NewValue> {
         let d = Deferred<NewValue>()
         upon(queue) {
             d.fill(transform($0))
@@ -160,14 +160,14 @@ public extension FutureType {
     }
 }
 
-public extension FutureType {
+extension FutureType {
     /// Composes this future with another.
     ///
     /// - parameter other: Any other future.
     /// - returns: A value that becomes determined after both the reciever and
     ///   the given future become determined.
     /// - seealso: SequenceType.allFutures
-    func and<OtherFuture: FutureType>(other: OtherFuture) -> Future<(Value, OtherFuture.Value)> {
+    public func and<OtherFuture: FutureType>(other: OtherFuture) -> Future<(Value, OtherFuture.Value)> {
         return Future(flatMap { t in other.map { u in (t, u) } })
     }
     
@@ -178,7 +178,7 @@ public extension FutureType {
     /// - returns: A value that becomes determined after the reciever and both
     ///   other futures become determined.
     /// - seealso: SequenceType.allFutures
-    func and<Other1: FutureType, Other2: FutureType>(one: Other1, _ two: Other2) -> Future<(Value, Other1.Value, Other2.Value)> {
+    public func and<Other1: FutureType, Other2: FutureType>(one: Other1, _ two: Other2) -> Future<(Value, Other1.Value, Other2.Value)> {
         return Future(flatMap { t in
             one.flatMap { u in
                 two.map { v in (t, u, v) }
@@ -194,7 +194,7 @@ public extension FutureType {
     /// - returns: A value that becomes determined after the reciever and both
     ///   other futures become determined.
     /// - seealso: SequenceType.allFutures
-    func and<Other1: FutureType, Other2: FutureType, Other3: FutureType>(one: Other1, _ two: Other2, _ three: Other3) -> Future<(Value, Other1.Value, Other2.Value, Other3.Value)> {
+    public func and<Other1: FutureType, Other2: FutureType, Other3: FutureType>(one: Other1, _ two: Other2, _ three: Other3) -> Future<(Value, Other1.Value, Other2.Value, Other3.Value)> {
         return Future(flatMap { t in
             one.flatMap { u in
                 two.flatMap { v in

--- a/Sources/PromiseType.swift
+++ b/Sources/PromiseType.swift
@@ -36,7 +36,7 @@ public protocol PromiseType {
     func fill(value: Value) -> Bool
 }
 
-public extension PromiseType {
+extension PromiseType {
     /// Determines the deferred value with a given result.
     ///
     /// Filling a deferred value should usually be attempted only once. An
@@ -56,7 +56,7 @@ public extension PromiseType {
     ///
     /// - parameter value: A resolved value for the instance.
     /// - parameter assertIfFilled: If `false`, race checking is disabled.
-    func fill(value: Value, assertIfFilled: Bool, file: StaticString = #file, line: UInt = #line) {
+    public func fill(value: Value, assertIfFilled: Bool, file: StaticString = #file, line: UInt = #line) {
         if !fill(value) && assertIfFilled {
             assertionFailure("Cannot fill an already-filled \(self.dynamicType)", file: file, line: line)
         }


### PR DESCRIPTION
#### What's in this pull request?

Slight access control cleanups in concrete extensions to add clarity and to reduce the effect of errant copypasta on `FutureType` access control.

#### Testing

Existing testing mechanisms will be sufficient. Await Travis approval. :construction_worker: 

#### API Changes

Only semantic differences to the code.

