### PR TITLE
Replace IgnoringFuture.init(_:) with ignored()

### DIFF
--- a/Sources/IgnoringFuture.swift
+++ b/Sources/IgnoringFuture.swift
@@ -3,7 +3,7 @@
 //  Deferred
 //
 //  Created by Zachary Waldowski on 9/3/15.
-//  Copyright © 2014-2015 Big Nerd Ranch. Licensed under MIT.
+//  Copyright © 2014-2016 Big Nerd Ranch. Licensed under MIT.
 //
 
 /// A wrapped future that discards the result of the future. The wrapped
@@ -20,7 +20,7 @@ public struct IgnoringFuture<Base: FutureType>: FutureType {
     private let base: Base
     
     /// Creates a future that ignores the result of `base`.
-    public init(_ base: Base) {
+    private init(_ base: Base) {
         self.base = base
     }
 
@@ -41,4 +41,21 @@ public struct IgnoringFuture<Base: FutureType>: FutureType {
     public func wait(time: Timeout) -> ()? {
         return base.wait(time).map { _ in }
     }
+}
+
+extension FutureType {
+
+    /// Returns a future that ignores the result of this future.
+    ///
+    /// This is semantically identical to the following:
+    ///
+    ///     myFuture.map { _ in }
+    ///
+    /// But behaves more efficiently.
+    ///
+    /// - seealso: map(upon:_:)
+    public func ignored() -> IgnoringFuture<Self> {
+        return IgnoringFuture(self)
+    }
+
 }

--- a/Tests/IgnoringFutureTests.swift
+++ b/Tests/IgnoringFutureTests.swift
@@ -21,7 +21,7 @@ class IgnoringFutureTests: XCTestCase {
 
     func testWaitWithTimeout() {
         let deferred = Deferred<Int>()
-        future = IgnoringFuture(deferred)
+        future = deferred.ignored()
 
         let expect = expectationWithDescription("value blocks while unfilled")
         after(1, upon: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
@@ -37,7 +37,7 @@ class IgnoringFutureTests: XCTestCase {
 
     func testIgnoredUponCalledWhenFilled() {
         let d = Deferred<Int>()
-        future = IgnoringFuture(d)
+        future = d.ignored()
 
         for _ in 0 ..< 10 {
             let expect = expectationWithDescription("upon blocks not called while deferred is unfilled")


### PR DESCRIPTION
#### What's in this pull request?

Backport method from #75. This will allow us to replace the type `IgnoringFuture` after 2.0.

#### Testing

Covered by existing infra with syntax changes.

#### API Changes

Source incompatible change before we seal 2.0 to allow for a source compatible change in 2.x.
