### PR TITLE
Remove overridden mirror for Future<Value>

### DIFF
--- a/Sources/ExistentialFuture.swift
+++ b/Sources/ExistentialFuture.swift
@@ -121,9 +121,4 @@ public struct Future<Value>: FutureType {
     public func wait(time: Timeout) -> Value? {
         return box.wait(time)
     }
-
-    /// Return the `Mirror` for `self`.
-    public func customMirror() -> Mirror {
-        return Mirror(reflecting: box)
-    }
 }


### PR DESCRIPTION
#### What's in this pull request?

Removes an override introduced in #80.

Before the PR, `Future<T>` would appear in a playground as `Deferred.BlahFutureBox<T>SomeUUID`. That's not good. Now it returns to the default `FutureType` implementation, showing `(isFilled **false**)` etc.

#### Testing

As noted in #80, mirrors are not to be tested.

#### API Changes

Only affects debugging.