### PR TITLE
Task for NSURLSession

### DIFF
--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -49,6 +49,10 @@
 		DB4C05181CC1A3C500D03269 /* TaskAccumulatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB4C05171CC1A3C500D03269 /* TaskAccumulatorTests.swift */; };
 		DB4C05191CC1A3C500D03269 /* TaskAccumulatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB4C05171CC1A3C500D03269 /* TaskAccumulatorTests.swift */; };
 		DB4C051A1CC1A3C500D03269 /* TaskAccumulatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB4C05171CC1A3C500D03269 /* TaskAccumulatorTests.swift */; };
+		DB215F651CC18A1900A88450 /* FoundationTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB215F641CC18A1900A88450 /* FoundationTasks.swift */; };
+		DB215F661CC18A1900A88450 /* FoundationTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB215F641CC18A1900A88450 /* FoundationTasks.swift */; };
+		DB215F671CC18A1900A88450 /* FoundationTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB215F641CC18A1900A88450 /* FoundationTasks.swift */; };
+		DB215F681CC18A1900A88450 /* FoundationTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB215F641CC18A1900A88450 /* FoundationTasks.swift */; };
 		DB5F1A331CBAC17900B5BE9E /* FutureCustomExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5F1A321CBAC17900B5BE9E /* FutureCustomExecutorTests.swift */; };
 		DB5F1A341CBAC17900B5BE9E /* FutureCustomExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5F1A321CBAC17900B5BE9E /* FutureCustomExecutorTests.swift */; };
 		DB5F1A351CBAC17900B5BE9E /* FutureCustomExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5F1A321CBAC17900B5BE9E /* FutureCustomExecutorTests.swift */; };
@@ -203,6 +207,7 @@
 		DB215F5F1CC1874600A88450 /* IgnoringTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IgnoringTask.swift; sourceTree = "<group>"; };
 		DB4C05121CC1A2B400D03269 /* TaskAccumulator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskAccumulator.swift; sourceTree = "<group>"; };
 		DB4C05171CC1A3C500D03269 /* TaskAccumulatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskAccumulatorTests.swift; sourceTree = "<group>"; };
+		DB215F641CC18A1900A88450 /* FoundationTasks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationTasks.swift; sourceTree = "<group>"; };
 		DB5F1A321CBAC17900B5BE9E /* FutureCustomExecutorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureCustomExecutorTests.swift; sourceTree = "<group>"; };
 		DB5F1A361CBAD61500B5BE9E /* ExistentialTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExistentialTask.swift; sourceTree = "<group>"; };
 		DB6ADFD31C237DD500D77BF1 /* Deferred.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Deferred.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -404,6 +409,7 @@
 				DB215F371CC16F9700A88450 /* BlockCancellableTask.swift */,
 				DB215F5F1CC1874600A88450 /* IgnoringTask.swift */,
 				DB5F1A361CBAD61500B5BE9E /* ExistentialTask.swift */,
+				DB215F641CC18A1900A88450 /* FoundationTasks.swift */,
 				DB215F2D1CC16F6B00A88450 /* ResultFuture.swift */,
 				DB215F321CC16F7D00A88450 /* ResultPromise.swift */,
 				DB4C05121CC1A2B400D03269 /* TaskAccumulator.swift */,
@@ -717,6 +723,7 @@
 				DB6AE0671C237F8800D77BF1 /* Timeout.swift in Sources */,
 				DB215F501CC1788A00A88450 /* TaskRecover.swift in Sources */,
 				DB6AE04B1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
+				DB215F661CC18A1900A88450 /* FoundationTasks.swift in Sources */,
 				DB215F341CC16F7D00A88450 /* ResultPromise.swift in Sources */,
 				DB6AE0471C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
 				DB215F391CC16F9700A88450 /* BlockCancellableTask.swift in Sources */,
@@ -772,6 +779,7 @@
 				DB6AE0661C237F8800D77BF1 /* Timeout.swift in Sources */,
 				DB215F4F1CC1788A00A88450 /* TaskRecover.swift in Sources */,
 				DB6AE04A1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
+				DB215F651CC18A1900A88450 /* FoundationTasks.swift in Sources */,
 				DB215F331CC16F7D00A88450 /* ResultPromise.swift in Sources */,
 				DB6AE0461C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
 				DB215F381CC16F9700A88450 /* BlockCancellableTask.swift in Sources */,
@@ -827,6 +835,7 @@
 				DB6AE0681C237F8800D77BF1 /* Timeout.swift in Sources */,
 				DB215F511CC1788A00A88450 /* TaskRecover.swift in Sources */,
 				DB6AE04C1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
+				DB215F671CC18A1900A88450 /* FoundationTasks.swift in Sources */,
 				DB215F351CC16F7D00A88450 /* ResultPromise.swift in Sources */,
 				DB6AE0481C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
 				DB215F3A1CC16F9700A88450 /* BlockCancellableTask.swift in Sources */,
@@ -882,6 +891,7 @@
 				DB6AE0691C237F8800D77BF1 /* Timeout.swift in Sources */,
 				DB215F521CC1788A00A88450 /* TaskRecover.swift in Sources */,
 				DB6AE04D1C237F8800D77BF1 /* FutureCollections.swift in Sources */,
+				DB215F681CC18A1900A88450 /* FoundationTasks.swift in Sources */,
 				DB215F361CC16F7D00A88450 /* ResultPromise.swift in Sources */,
 				DB6AE0491C237F8800D77BF1 /* ExistentialFuture.swift in Sources */,
 				DB215F3B1CC16F9700A88450 /* BlockCancellableTask.swift in Sources */,

--- a/Sources/Task/FoundationTasks.swift
+++ b/Sources/Task/FoundationTasks.swift
@@ -1,0 +1,107 @@
+//
+//  FoundationTasks.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 1/10/16.
+//  Copyright © 2016 Big Nerd Ranch. Licensed under MIT.
+//
+
+#if SWIFT_PACKAGE
+import Deferred
+import Result
+#endif
+import Foundation
+
+extension NSURLSession {
+
+    private func beginTask<URLTask: NSURLSessionTask>(@noescape with factoryWithCompletion: ((NSData?, NSURLResponse?, NSError?) -> Void) -> URLTask, @noescape by configuring: URLTask throws -> Void, @autoclosure(escaping) needsDefaultData: () -> Bool) rethrows -> Task<(NSData, NSURLResponse)> {
+        let deferred = Deferred<Task<(NSData, NSURLResponse)>.Result>()
+        let task = factoryWithCompletion { (data, response, error) in
+            if let error = error {
+                deferred.fail(error)
+            } else if let data = data, let response = response {
+                deferred.succeed((data, response))
+            } else if let response = response where needsDefaultData() {
+                deferred.succeed((NSData(), response))
+            } else {
+                deferred.fail(NSURLError.BadServerResponse)
+            }
+        }
+        try configuring(task)
+        defer { task.resume() }
+        return Task(deferred, cancellation: task.cancel)
+    }
+
+    // MARK: - Sending and Recieving Small Data
+
+    /// Returns the data from the contents of a URL, based on `request`, as a
+    /// future.
+    ///
+    /// The session bypasses delegate methods for result delivery. Delegate
+    /// methods for handling authentication challenges are still called.
+    ///
+    /// - parameter request: Object that provides the URL, body data, and so on.
+    /// - parameter configure: An optional callback for setting properties on
+    ///   the URL task.
+    public func beginDataTask(with request: NSURLRequest, @noescape by configuring: NSURLSessionDataTask throws -> Void) rethrows -> Task<(NSData, NSURLResponse)> {
+        return try beginTask(with: { completionHandler in
+            dataTaskWithRequest(request, completionHandler: completionHandler)
+        }, by: configuring, needsDefaultData: {
+            switch request.HTTPMethod {
+            case "GET"?, "POST"?, "PATCH"?:
+                return false
+            default:
+                return true
+            }
+        }())
+    }
+
+    /// Returns the data from the contents of a URL, based on `request`, as a
+    /// future.
+    public func beginDataTask(request request: NSURLRequest) -> Task<(NSData, NSURLResponse)> {
+        return beginDataTask(with: request) { _ in }
+    }
+
+    // MARK: - Uploading Data
+
+    /// Returns the data from uploading the optional `bodyData` as a future.
+    ///
+    /// The session bypasses delegate methods for result delivery. Delegate
+    /// methods for handling authentication challenges are still called.
+    ///
+    /// - parameter request: Object that provides the URL, body data, and so on.
+    ///   The body stream and body data are ignored.
+    /// - parameter configure: An optional callback for setting properties on
+    ///   the URL task.
+    public func beginUploadTask(with request: NSURLRequest, from bodyData: NSData? = nil, @noescape by configuring: NSURLSessionUploadTask throws -> Void) rethrows -> Task<(NSData, NSURLResponse)> {
+        return try beginTask(with: { completionHandler in
+            uploadTaskWithRequest(request, fromData: bodyData, completionHandler: completionHandler)
+        }, by: configuring, needsDefaultData: true)
+    }
+
+    /// Returns the data from uploading the optional `bodyData` as a future.
+    public func beginUploadTask(with request: NSURLRequest, from bodyData: NSData? = nil) -> Task<(NSData, NSURLResponse)> {
+        return beginUploadTask(with: request, from: bodyData) { _ in }
+    }
+
+    /// Returns the data from uploading the file at `fileURL` as a future.
+    ///
+    /// The session bypasses delegate methods for result delivery. Delegate
+    /// methods for handling authentication challenges are still called.
+    ///
+    /// - parameter request: Object that provides the URL, body data, and so on.
+    ///   The body stream and body data are ignored.
+    /// - parameter configure: An optional callback for setting properties on
+    ///   the URL task.
+    public func beginUploadTask(with request: NSURLRequest, fromFile fileURL: NSURL, @noescape by configuring: NSURLSessionUploadTask throws -> Void) rethrows -> Task<(NSData, NSURLResponse)> {
+        return try beginTask(with: { completionHandler in
+            uploadTaskWithRequest(request, fromFile: fileURL, completionHandler: completionHandler)
+        }, by: configuring, needsDefaultData: true)
+    }
+
+    /// Returns the data from uploading the file at `fileURL` as a future.
+    public func beginUploadTask(with request: NSURLRequest, fromFile fileURL: NSURL) -> Task<(NSData, NSURLResponse)> {
+        return beginUploadTask(with: request, fromFile: fileURL) { _ in }
+    }
+
+}


### PR DESCRIPTION
See #98.

#### What's in this pull request?

Initially intended for inclusion in #98 (and, indeed, the genesis of the idea of `Task` entirely), this PR needs some separate consideration.

It needs another pass at design; I'm particularly concerned at losing the original `NSURLSessionTask` reference, the lack of progress reporting, and the lack of compatibility with delegate-based URL sessions.

#### Testing

- [ ] Needs a major pass at test coverage.

#### API Changes

Additions are additive.

API will naturally be broken majorly for Swift 3. See #101.