### PR TITLE
Task: Progress Reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,8 @@ env:
   global:
     secure: cqco7locH7wY0iSSQTyvSUHmCRNsxrXSPi65HgVHLKhAfNrto/SYKw68PokkVdTLaJlzcglOMFFZnwHcX0ubSgaWt4xiGd3Kx9aFQC/uHc8Nt7w56sG8DlUG1C+5rlsiayNwlqXNZuQizrDeqTYtiECDavIlcFdwk4JknlOMKUc=
 script:
-- scan -s Deferred
-- scan -s MobileDeferred --devices "iPhone 5s (8.4)", "iPhone 6s (9.3)"
-- scan -s TVDeferred
-- carthage build --no-skip-current --configuration Debug
-- pod lib lint --quick
+- env NSUnbufferedIO=YES xcodebuild -scheme MobileDeferred -project ./Deferred.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 6' build test
+- env NSUnbufferedIO=YES xcodebuild -scheme MobileDeferred -project ./Deferred.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 6,OS=8.4' build test
 after_success:
 - "./Configurations/publish_docs.sh"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,18 @@
 language: objective-c
 osx_image: xcode7.3
+rvm:
+- 2.2.2
 install:
-- gem install scan --no-rdoc --no-ri --no-document --quiet
-- gem install cocoapods --no-rdoc --no-ri --no-document --quiet
-- gem install jazzy --no-rdoc --no-ri --no-document --quiet
+- bundle install --jobs=3 --retry=3
 - brew install carthage --force-bottle
 env:
   matrix:
   - SCAN_OPEN_REPORT=false
   global:
     secure: cqco7locH7wY0iSSQTyvSUHmCRNsxrXSPi65HgVHLKhAfNrto/SYKw68PokkVdTLaJlzcglOMFFZnwHcX0ubSgaWt4xiGd3Kx9aFQC/uHc8Nt7w56sG8DlUG1C+5rlsiayNwlqXNZuQizrDeqTYtiECDavIlcFdwk4JknlOMKUc=
-before_script:
-- set -o pipefail
 script:
 - scan -s Deferred
-- scan -s MobileDeferred
+- scan -s MobileDeferred --devices "iPhone 5s (8.4)", "iPhone 6s (9.3)"
 - scan -s TVDeferred
 - carthage build --no-skip-current --configuration Debug
 - pod lib lint --quick

--- a/Configurations/publish_docs.sh
+++ b/Configurations/publish_docs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ev
 
 echo -e "Generating Jazzy output \n"
 jazzy --clean --config .jazzy.yml
@@ -15,7 +16,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; th
     echo -e "Adding new docs \n"
     git add -A
     git commit -m "Publish docs from successful Travis build of $TRAVIS_COMMIT"
-    git push --force --quiet "https://${GITHUB_ACCESS_TOKEN}@github.com/bignerdranch/Deferred" master:gh-pages > /dev/null 2>&1
+    git push --force --quiet "https://${GITHUB_ACCESS_TOKEN}@github.com/${TRAVIS_REPO_SLUG}" master:gh-pages > /dev/null 2>&1
     echo -e "Published latest docs.\n"
 
     echo -e "Moving out of docs clone and cleaning up"

--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -134,6 +134,10 @@
 		DB8CFEFC1CB048B200D095B7 /* ExecutorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8CFEFA1CB048B200D095B7 /* ExecutorType.swift */; };
 		DB8CFEFD1CB048B200D095B7 /* ExecutorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8CFEFA1CB048B200D095B7 /* ExecutorType.swift */; };
 		DB8CFEFE1CB048B200D095B7 /* ExecutorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8CFEFA1CB048B200D095B7 /* ExecutorType.swift */; };
+		DB915D0A1D67814400073364 /* TaskProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB915D091D67814400073364 /* TaskProgress.swift */; };
+		DB915D0B1D67814400073364 /* TaskProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB915D091D67814400073364 /* TaskProgress.swift */; };
+		DB915D0C1D67814400073364 /* TaskProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB915D091D67814400073364 /* TaskProgress.swift */; };
+		DB915D0D1D67814400073364 /* TaskProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB915D091D67814400073364 /* TaskProgress.swift */; };
 		DB9976921C2F1AAA005201CE /* TaskResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB99768E1C2F1AAA005201CE /* TaskResult.swift */; };
 		DB9976931C2F1AAA005201CE /* TaskResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB99768E1C2F1AAA005201CE /* TaskResult.swift */; };
 		DB9976941C2F1AAA005201CE /* TaskResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB99768E1C2F1AAA005201CE /* TaskResult.swift */; };
@@ -239,6 +243,7 @@
 		DB8CFEF01CB047F200D095B7 /* FutureMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FutureMap.swift; path = Deferred/FutureMap.swift; sourceTree = "<group>"; };
 		DB8CFEF51CB047F800D095B7 /* FutureFlatMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FutureFlatMap.swift; path = Deferred/FutureFlatMap.swift; sourceTree = "<group>"; };
 		DB8CFEFA1CB048B200D095B7 /* ExecutorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExecutorType.swift; path = Deferred/ExecutorType.swift; sourceTree = "<group>"; };
+		DB915D091D67814400073364 /* TaskProgress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskProgress.swift; sourceTree = "<group>"; };
 		DB99768E1C2F1AAA005201CE /* TaskResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskResult.swift; sourceTree = "<group>"; };
 		DB9976901C2F1AAA005201CE /* ResultRecovery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultRecovery.swift; sourceTree = "<group>"; };
 		DB9976911C2F1AAA005201CE /* ResultType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultType.swift; sourceTree = "<group>"; };
@@ -410,6 +415,7 @@
 				DB215F281CC16F5300A88450 /* TaskCollections.swift */,
 				DB215F531CC17B2D00A88450 /* TaskFlatMap.swift */,
 				DB215F401CC1704300A88450 /* TaskMap.swift */,
+				DB915D091D67814400073364 /* TaskProgress.swift */,
 				DB215F4E1CC1788A00A88450 /* TaskRecover.swift */,
 				DBDAC8C61CA9D4F80087EA91 /* TaskType.swift */,
 			);
@@ -708,6 +714,7 @@
 				DB5F1A381CBAD61500B5BE9E /* ExistentialTask.swift in Sources */,
 				DB6AE0631C237F8800D77BF1 /* ReadWriteLock.swift in Sources */,
 				DB215F2F1CC16F6B00A88450 /* ResultFuture.swift in Sources */,
+				DB915D0B1D67814400073364 /* TaskProgress.swift in Sources */,
 				DB215F551CC17B2D00A88450 /* TaskFlatMap.swift in Sources */,
 				DB8CFEF71CB047F800D095B7 /* FutureFlatMap.swift in Sources */,
 				DB6AE0571C237F8800D77BF1 /* LockProtected.swift in Sources */,
@@ -763,6 +770,7 @@
 				DB5F1A371CBAD61500B5BE9E /* ExistentialTask.swift in Sources */,
 				DB6AE0621C237F8800D77BF1 /* ReadWriteLock.swift in Sources */,
 				DB215F2E1CC16F6B00A88450 /* ResultFuture.swift in Sources */,
+				DB915D0A1D67814400073364 /* TaskProgress.swift in Sources */,
 				DB215F541CC17B2D00A88450 /* TaskFlatMap.swift in Sources */,
 				DB8CFEF61CB047F800D095B7 /* FutureFlatMap.swift in Sources */,
 				DB6AE0561C237F8800D77BF1 /* LockProtected.swift in Sources */,
@@ -818,6 +826,7 @@
 				DB5F1A391CBAD61500B5BE9E /* ExistentialTask.swift in Sources */,
 				DB6AE0641C237F8800D77BF1 /* ReadWriteLock.swift in Sources */,
 				DB215F301CC16F6B00A88450 /* ResultFuture.swift in Sources */,
+				DB915D0C1D67814400073364 /* TaskProgress.swift in Sources */,
 				DB215F561CC17B2D00A88450 /* TaskFlatMap.swift in Sources */,
 				DB8CFEF81CB047F800D095B7 /* FutureFlatMap.swift in Sources */,
 				DB6AE0581C237F8800D77BF1 /* LockProtected.swift in Sources */,
@@ -873,6 +882,7 @@
 				DB5F1A3A1CBAD61500B5BE9E /* ExistentialTask.swift in Sources */,
 				DB6AE0651C237F8800D77BF1 /* ReadWriteLock.swift in Sources */,
 				DB215F311CC16F6B00A88450 /* ResultFuture.swift in Sources */,
+				DB915D0D1D67814400073364 /* TaskProgress.swift in Sources */,
 				DB215F571CC17B2D00A88450 /* TaskFlatMap.swift in Sources */,
 				DB8CFEF91CB047F800D095B7 /* FutureFlatMap.swift in Sources */,
 				DB6AE0591C237F8800D77BF1 /* LockProtected.swift in Sources */,

--- a/Deferred.xcodeproj/xcshareddata/xcschemes/MobileDeferred.xcscheme
+++ b/Deferred.xcodeproj/xcshareddata/xcschemes/MobileDeferred.xcscheme
@@ -52,6 +52,74 @@
                BlueprintName = "MobileDeferredTests"
                ReferencedContainer = "container:Deferred.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "BlockCancellationTests">
+               </Test>
+               <Test
+                  Identifier = "CustomExecutorTestCase">
+               </Test>
+               <Test
+                  Identifier = "CustomQueueTestCase">
+               </Test>
+               <Test
+                  Identifier = "DeferredTests">
+               </Test>
+               <Test
+                  Identifier = "ExistentialFutureTests">
+               </Test>
+               <Test
+                  Identifier = "FutureCustomExecutorTests">
+               </Test>
+               <Test
+                  Identifier = "IgnoringFutureTests">
+               </Test>
+               <Test
+                  Identifier = "LockProtectedTests">
+               </Test>
+               <Test
+                  Identifier = "ReadWriteLockTests">
+               </Test>
+               <Test
+                  Identifier = "ResultRecoveryTests">
+               </Test>
+               <Test
+                  Identifier = "ResultTests">
+               </Test>
+               <Test
+                  Identifier = "TaskAccumulatorTests">
+               </Test>
+               <Test
+                  Identifier = "TaskCustomExecutorTests">
+               </Test>
+               <Test
+                  Identifier = "TaskCustomQueueTests">
+               </Test>
+               <Test
+                  Identifier = "TaskTests/testThatMapPassesThroughErrors()">
+               </Test>
+               <Test
+                  Identifier = "TaskTests/testThatRecoverMapsFailures()">
+               </Test>
+               <Test
+                  Identifier = "TaskTests/testThatRecoverPassesThroughValues()">
+               </Test>
+               <Test
+                  Identifier = "TaskTests/testThatThrowingFlatMapSubstitutesWithError()">
+               </Test>
+               <Test
+                  Identifier = "TaskTests/testThatThrowingMapSubstitutesWithError()">
+               </Test>
+               <Test
+                  Identifier = "TaskTests/testUponFailure()">
+               </Test>
+               <Test
+                  Identifier = "TaskTests/testUponSuccess()">
+               </Test>
+               <Test
+                  Identifier = "VoidResultTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>
@@ -86,6 +154,11 @@
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'scan', git: 'https://github.com/fastlane/fastlane.git'
+gem 'cocoapods'
+gem 'jazzy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,132 @@
+GIT
+  remote: https://github.com/fastlane/fastlane.git
+  revision: eecf3e96857d593a719d52df25e6bb3f7ae374fd
+  specs:
+    credentials_manager (0.16.0)
+      colored
+      commander (>= 4.3.5)
+      highline (>= 1.7.1)
+      security
+    scan (0.11.3)
+      fastlane_core (>= 0.50.0, < 1.0.0)
+      slack-notifier (~> 1.3)
+      terminal-table
+      xcpretty (>= 0.2.1)
+      xcpretty-travis-formatter (>= 0.0.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    babosa (1.0.2)
+    claide (1.0.0)
+    cocoapods (1.0.1)
+      activesupport (>= 4.0.2)
+      claide (>= 1.0.0, < 2.0)
+      cocoapods-core (= 1.0.1)
+      cocoapods-deintegrate (>= 1.0.0, < 2.0)
+      cocoapods-downloader (>= 1.0.0, < 2.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-stats (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.0.0, < 2.0)
+      cocoapods-try (>= 1.0.0, < 2.0)
+      colored (~> 1.2)
+      escape (~> 0.0.4)
+      fourflusher (~> 0.3.0)
+      molinillo (~> 0.4.5)
+      nap (~> 1.0)
+      xcodeproj (>= 1.1.0, < 2.0)
+    cocoapods-core (1.0.1)
+      activesupport (>= 4.0.2)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
+    cocoapods-deintegrate (1.0.0)
+    cocoapods-downloader (1.1.0)
+    cocoapods-plugins (1.0.0)
+      nap
+    cocoapods-search (1.0.0)
+    cocoapods-stats (1.0.0)
+    cocoapods-trunk (1.0.0)
+      nap (>= 0.8, < 2.0)
+      netrc (= 0.7.8)
+    cocoapods-try (1.1.0)
+    colored (1.2)
+    commander (4.4.0)
+      highline (~> 1.7.2)
+    concurrent-ruby (1.0.2)
+    escape (0.0.4)
+    excon (0.45.4)
+    fastlane_core (0.50.3)
+      babosa
+      colored
+      commander (>= 4.4.0, <= 5.0.0)
+      credentials_manager (>= 0.16.0, < 1.0.0)
+      excon (~> 0.45.0)
+      gh_inspector (>= 1.0.1, < 2.0.0)
+      highline (>= 1.7.2)
+      json
+      multi_json
+      plist (~> 3.1)
+      rubyzip (~> 1.1.6)
+      terminal-table (~> 1.4.5)
+    fourflusher (0.3.2)
+    fuzzy_match (2.0.4)
+    gh_inspector (1.0.2)
+    highline (1.7.8)
+    i18n (0.7.0)
+    jazzy (0.7.0)
+      cocoapods (~> 1.0)
+      mustache (~> 0.99)
+      open4
+      redcarpet (~> 3.2)
+      rouge (~> 1.5)
+      sass (~> 3.4)
+      sqlite3 (~> 1.3)
+      xcinvoke (~> 0.2.1)
+    json (2.0.2)
+    liferaft (0.0.4)
+    minitest (5.9.0)
+    molinillo (0.4.5)
+    multi_json (1.12.1)
+    mustache (0.99.8)
+    nap (1.1.0)
+    netrc (0.7.8)
+    open4 (1.3.4)
+    plist (3.2.0)
+    redcarpet (3.3.4)
+    rouge (1.11.1)
+    rubyzip (1.1.7)
+    sass (3.4.22)
+    security (0.1.3)
+    slack-notifier (1.5.1)
+    sqlite3 (1.3.11)
+    terminal-table (1.4.5)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    xcinvoke (0.2.1)
+      liferaft (~> 0.0.4)
+    xcodeproj (1.2.0)
+      activesupport (>= 3)
+      claide (>= 1.0.0, < 2.0)
+      colored (~> 1.2)
+    xcpretty (0.2.2)
+      rouge (~> 1.8)
+    xcpretty-travis-formatter (0.0.4)
+      xcpretty (~> 0.2, >= 0.0.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cocoapods
+  jazzy
+  scan!
+
+BUNDLED WITH
+   1.12.5

--- a/Sources/Result/BlockCancellableTask.swift
+++ b/Sources/Result/BlockCancellableTask.swift
@@ -25,7 +25,7 @@ extension Task {
     /// - parameter body: A failable closure creating and returning the
     ///   success value of the task.
     /// - seealso: dispatch_block_flags_t
-    public init(upon queue: dispatch_queue_t = Task<SuccessValue>.genericQueue, per options: dispatch_block_flags_t = [], @autoclosure(escaping) onCancel produceError: () -> ErrorType, body: () throws -> SuccessValue) {
+    public convenience init(upon queue: dispatch_queue_t = Task<SuccessValue>.genericQueue, per options: dispatch_block_flags_t = [], @autoclosure(escaping) onCancel produceError: () -> ErrorType, body: () throws -> SuccessValue) {
         let deferred = Deferred<Result>()
 
         let block = dispatch_block_create(options) {

--- a/Sources/Task/IgnoringTask.swift
+++ b/Sources/Task/IgnoringTask.swift
@@ -10,7 +10,7 @@
 import Deferred
 import Result
 #endif
-import Dispatch
+import Foundation
 
 private extension ResultType {
     func ignored() -> TaskResult<Void> {
@@ -22,17 +22,19 @@ public struct IgnoringTask<Base: FutureType where Base.Value: ResultType> {
     public typealias Result = TaskResult<Void>
 
     private let base: Base
-    private let cancellation: Cancellation
+    public let progress: NSProgress
 
-    /// Creates an event given with a `base` future and an optional
-    /// `cancellation`.
-    private init(_ base: Base, cancellation: Cancellation) {
+    /// Creates an event given with a `base` future and its `progress`.
+    private init(_ base: Base, progress: NSProgress) {
         self.base = base
-        self.cancellation = cancellation
+        self.progress = progress
     }
 }
 
-extension IgnoringTask: FutureType {
+extension IgnoringTask: TaskType {
+    /// A type that represents the result of some asynchronous event.
+    public typealias Value = Result
+
     /// Call some function once the event completes.
     ///
     /// If the event is already completed, the function will be submitted to the
@@ -54,13 +56,6 @@ extension IgnoringTask: FutureType {
     }
 }
 
-extension IgnoringTask: TaskType {
-    /// Attempt to cancel the underlying operation. This is a "best effort".
-    public func cancel() {
-        cancellation()
-    }
-}
-
 extension TaskType {
     /// Returns a task that ignores the successful completion of this task.
     ///
@@ -74,6 +69,6 @@ extension TaskType {
     ///
     /// - seealso: map(_:)
     public func ignored() -> IgnoringTask<Self> {
-        return IgnoringTask(self, cancellation: cancel)
+        return IgnoringTask(self, progress: progress)
     }
 }

--- a/Sources/Task/TaskFlatMap.swift
+++ b/Sources/Task/TaskFlatMap.swift
@@ -10,22 +10,20 @@
 import Deferred
 import Result
 #endif
-import Dispatch
-
-private func commonFlatMap<OldResult: ResultType, NewTask: TaskType>(startNextTask: OldResult.Value throws -> NewTask, cancellationToken: Deferred<Void>) -> (OldResult) -> Future<NewTask.Value> {
-    return { result in
-        do {
-            let newTask = try startNextTask(result.extract())
-            cancellationToken.upon(newTask.cancel)
-            return Future(newTask)
-        } catch {
-            return Future(value: NewTask.Value(error: error))
-        }
-    }
-}
+import Foundation
 
 extension TaskType {
-    private typealias OldSuccessValue = Value.Value
+    private typealias SuccessValue = Value.Value
+    private func commonBody<NewTask: TaskType>(for startNextTask: SuccessValue throws -> NewTask) -> (NSProgress, (Value) -> Task<NewTask.Value.Value>) {
+        return extendingTask(unitCount: 1) { (result) in
+            do {
+                let newTask = try startNextTask(result.extract())
+                return Task(newTask, progress: newTask.progress)
+            } catch {
+                return Task(error: error)
+            }
+        }
+    }
 
     /// Begins another task by passing the result of the task to `startNextTask`
     /// once it completes successfully.
@@ -37,10 +35,10 @@ extension TaskType {
     /// `startNextTask` closure. `flatMap` submits `startNextTask` to `executor`
     /// once the task completes successfully.
     /// - seealso: FutureType.flatMap(upon:_:)
-    public func flatMap<NewTask: TaskType>(upon executor: ExecutorType, _ startNextTask: OldSuccessValue throws -> NewTask) -> Task<NewTask.Value.Value> {
-        let cancellationToken = Deferred<Void>()
-        let mapped = flatMap(upon: executor, commonFlatMap(startNextTask, cancellationToken: cancellationToken))
-        return Task(mapped) { _ = cancellationToken.fill() }
+    public func flatMap<NewTask: TaskType>(upon executor: ExecutorType, _ startNextTask: SuccessValue throws -> NewTask) -> Task<NewTask.Value.Value> {
+        let (progress, body) = commonBody(for: startNextTask)
+        let future = flatMap(upon: executor, body)
+        return Task(future: future, progress: progress)
     }
 
     /// Begins another task by passing the result of the task to `startNextTask`
@@ -51,10 +49,10 @@ extension TaskType {
     /// asynchronously once the task completes successfully.
     /// - seealso: flatMap(upon:_:)
     /// - seealso: FutureType.flatMap(upon:_:)
-    public func flatMap<NewTask: TaskType>(upon queue: dispatch_queue_t, _ startNextTask: OldSuccessValue throws -> NewTask) -> Task<NewTask.Value.Value> {
-        let cancellationToken = Deferred<Void>()
-        let mapped = flatMap(upon: queue, commonFlatMap(startNextTask, cancellationToken: cancellationToken))
-        return Task(mapped) { _ = cancellationToken.fill() }
+    public func flatMap<NewTask: TaskType>(upon queue: dispatch_queue_t, _ startNextTask: SuccessValue throws -> NewTask) -> Task<NewTask.Value.Value> {
+        let (progress, body) = commonBody(for: startNextTask)
+        let future = flatMap(upon: queue, body)
+        return Task(future: future, progress: progress)
     }
 
     /// Begins another task by passing the result of the task to `startNextTask`
@@ -65,9 +63,9 @@ extension TaskType {
     /// background once the task completes successfully.
     /// - seealso: flatMap(upon:_:)
     /// - seealso: FutureType.flatMap(_:)
-    public func flatMap<NewTask: TaskType>(startNextTask: OldSuccessValue throws -> NewTask) -> Task<NewTask.Value.Value> {
-        let cancellationToken = Deferred<Void>()
-        let mapped = flatMap(commonFlatMap(startNextTask, cancellationToken: cancellationToken))
-        return Task(mapped) { _ = cancellationToken.fill() }
+    public func flatMap<NewTask: TaskType>(startNextTask: SuccessValue throws -> NewTask) -> Task<NewTask.Value.Value> {
+        let (progress, body) = commonBody(for: startNextTask)
+        let future = flatMap(body)
+        return Task(future: future, progress: progress)
     }
 }

--- a/Sources/Task/TaskMap.swift
+++ b/Sources/Task/TaskMap.swift
@@ -10,55 +10,57 @@
 import Deferred
 import Result
 #endif
-import Dispatch
-
-private func commonMapSuccess<OldResult: ResultType, NewSuccessValue>(transform: OldResult.Value throws -> NewSuccessValue) -> (OldResult) -> TaskResult<NewSuccessValue> {
-    return { oldResult in
-        TaskResult {
-            try transform(oldResult.extract())
-        }
-    }
-}
+import Foundation
 
 extension TaskType {
-    private typealias OldSuccessValue = Value.Value
+    private typealias SuccessValue = Value.Value
+    private func commonBody<NewSuccessValue>(for transform: Value.Value throws -> NewSuccessValue) -> (NSProgress, (Value) -> TaskResult<NewSuccessValue>) {
+        return extendingTask(unitCount: 1) { (result) in
+            TaskResult {
+                try transform(result.extract())
+            }
+        }
+    }
 
     /// Returns a `Task` containing the result of mapping `transform` over the
     /// task's success value.
     ///
-    /// `map` submits the `transform` to the `executor` once the task completes.
+    /// The `transform` is submitted to the `executor` once the task completes.
     ///
     /// The resulting task is cancellable in the same way the recieving task is.
     ///
     /// - seealso: FutureType.map(upon:_:)
-    public func map<NewSuccessValue>(upon executor: ExecutorType, _ transform: OldSuccessValue throws -> NewSuccessValue) -> Task<NewSuccessValue> {
-        let future = map(upon: executor, commonMapSuccess(transform))
-        return .init(future, cancellation: cancel)
+    public func map<NewSuccessValue>(upon executor: ExecutorType, _ transform: SuccessValue throws -> NewSuccessValue) -> Task<NewSuccessValue> {
+        let (progress, body) = commonBody(for: transform)
+        let future = map(upon: executor, body)
+        return Task(future: future, progress: progress)
     }
 
     /// Returns a `Task` containing the result of mapping `transform` over the
     /// task's success value
     ///
-    /// `map` executes the `transform` asynchronously once the task completes.
+    /// The `transform` is submitted to the `executor` once the task completes.
     ///
     /// The resulting task is cancellable in the same way the recieving task is.
     ///
     /// - seealso: FutureType.map(upon:_:)
-    public func map<NewSuccessValue>(upon queue: dispatch_queue_t, _ transform: OldSuccessValue throws -> NewSuccessValue) -> Task<NewSuccessValue> {
-        let future = map(upon: queue, commonMapSuccess(transform))
-        return .init(future, cancellation: cancel)
+    public func map<NewSuccessValue>(upon queue: dispatch_queue_t, _ transform: SuccessValue throws -> NewSuccessValue) -> Task<NewSuccessValue> {
+        let (progress, body) = commonBody(for: transform)
+        let future = map(upon: queue, body)
+        return Task(future: future, progress: progress)
     }
 
     /// Returns a `Task` containing the result of mapping `transform` over the
     /// task's success value
     ///
-    /// `map` executes the `transform` in the background once the task completes.
+    /// The `transform` is submitted to the `executor` once the task completes.
     ///
     /// The resulting task is cancellable in the same way the recieving task is.
     ///
     /// - seealso: FutureType.map(_:)
-    public func map<NewSuccessValue>(transform: OldSuccessValue throws -> NewSuccessValue) -> Task<NewSuccessValue> {
-        let future = map(commonMapSuccess(transform))
-        return .init(future, cancellation: cancel)
+    public func map<NewSuccessValue>(transform: SuccessValue throws -> NewSuccessValue) -> Task<NewSuccessValue> {
+        let (progress, body) = commonBody(for: transform)
+        let future = map(body)
+        return Task(future: future, progress: progress)
     }
 }

--- a/Sources/Task/TaskProgress.swift
+++ b/Sources/Task/TaskProgress.swift
@@ -1,0 +1,252 @@
+//
+//  NSProgress.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 8/19/16.
+//  Copyright © 2016 Big Nerd Ranch. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Backports
+
+private struct KVO {
+    static var context = false
+    enum KeyPath: String {
+        case completedUnitCount
+        case totalUnitCount
+        case localizedDescription
+        case localizedAdditionalDescription
+        case cancellable
+        case pausable
+        case cancelled
+        case paused
+        case kind
+        static let all: [KeyPath] = [ .completedUnitCount, .totalUnitCount, .localizedDescription, .localizedAdditionalDescription, .cancellable, .pausable, .cancelled, .paused, .kind ]
+    }
+}
+
+private final class ProxyProgress: NSProgress {
+
+    var original: NSProgress!
+
+    init(cloning original: NSProgress) {
+        self.original = original
+        super.init(parent: .currentProgress(), userInfo: nil)
+        start()
+    }
+
+    func start() {
+        for keyPath in KVO.KeyPath.all {
+            original.addObserver(self, forKeyPath: keyPath.rawValue, options: [.Initial, .New], context: &KVO.context)
+        }
+        cancellationHandler = original.cancel
+        pausingHandler = original.pause
+        if #available(OSX 10.11, iOS 9.0, *) {
+            resumingHandler = original.resume
+        }
+    }
+
+    func invalidate() {
+        for keyPath in KVO.KeyPath.all {
+            original.removeObserver(self, forKeyPath: keyPath.rawValue, context: &KVO.context)
+        }
+        cancellationHandler = nil
+        pausingHandler = nil
+        if #available(OSX 10.11, iOS 9.0, *) {
+            resumingHandler = nil
+        }
+        original = nil
+    }
+
+    override func replacementObjectForCoder(aCoder: NSCoder) -> AnyObject? {
+        return original
+    }
+
+    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+        switch (keyPath, context) {
+        case (KVO.KeyPath.cancelled.rawValue?, &KVO.context):
+            guard change?[NSKeyValueChangeNewKey] as? Bool == true else { return }
+            cancellationHandler = nil
+            cancel()
+            cancellationHandler = original.cancel
+        case (KVO.KeyPath.paused.rawValue?, &KVO.context):
+            if change?[NSKeyValueChangeNewKey] as? Bool == true {
+                pausingHandler = nil
+                pause()
+                pausingHandler = original.pause
+            } else if #available(OSX 10.11, iOS 9.0, *) {
+                resumingHandler = nil
+                resume()
+                resumingHandler = original.resume
+            }
+        case (let keyPath?, &KVO.context):
+            setValue(change?[NSKeyValueChangeNewKey], forKeyPath: keyPath)
+        default:
+            super.observeValueForKeyPath(keyPath, ofObject: object, change: change, context: context)
+        }
+    }
+
+    override func becomeCurrentWithPendingUnitCount(unitCount: Int64) {
+        original.becomeCurrentWithPendingUnitCount(unitCount)
+    }
+
+    override func resignCurrent() {
+        original.resignCurrent()
+    }
+
+    @available(OSX 10.11, iOS 9.0, *)
+    override func addChild(child: NSProgress, withPendingUnitCount unitCount: Int64) {
+        original.addChild(child, withPendingUnitCount: unitCount)
+    }
+
+    @objc static func keyPathsForValuesAffectingUserInfo() -> Set<String> {
+        return [ "original.userInfo" ]
+    }
+
+    #if swift(>=2.3)
+    override var userInfo: [String : AnyObject] {
+        return original.userInfo
+    }
+    #else
+    override var userInfo: [NSObject : AnyObject] {
+        return original.userInfo
+    }
+    #endif
+
+    override func setUserInfoObject(object: AnyObject?, forKey key: String) {
+        original.setUserInfoObject(object, forKey: key)
+    }
+
+}
+
+extension NSProgress {
+
+    // Attempt a backwards-compatible implementation of iOS 9's explicit
+    // progress handling. It's not perfect; this is a best effort of proxying
+    // an external progress tree.
+    func addChild<Future: FutureType>(progress: NSProgress, for future: Future, withPendingUnitCount pendingUnitCount: Int64) {
+        if #available(OSX 10.11, iOS 9.0, *) {
+            addChild(progress, withPendingUnitCount: pendingUnitCount)
+        } else {
+            becomeCurrentWithPendingUnitCount(pendingUnitCount)
+            defer { resignCurrent() }
+
+            let wrapper = ProxyProgress(cloning: progress)
+            future.upon { _ in
+                wrapper.invalidate()
+            }
+        }
+    }
+
+}
+
+// MARK: - Convenience initializers
+
+extension NSProgress {
+
+    @nonobjc convenience init(discreteWithCount totalUnitCount: Int64) {
+        self.init(parent: nil, userInfo: nil)
+        self.totalUnitCount = totalUnitCount
+    }
+
+    @nonobjc convenience init(indefinite: ()) {
+        self.init(discreteWithCount: -1)
+        cancellable = false
+    }
+
+    @nonobjc convenience init(noWork: ()) {
+        self.init(discreteWithCount: 0)
+        completedUnitCount = 1
+        cancellable = false
+        pausable = false
+    }
+
+    // A simple indeterminate progress with a completion block.
+    @nonobjc convenience init<Future: FutureType>(future: Future, cancellation: ((Void) -> Void)?) {
+        self.init(discreteWithCount: future.isFilled ? 0 : -1)
+
+        if let cancellation = cancellation {
+            cancellationHandler = cancellation
+        } else {
+            cancellable = false
+        }
+
+        future.upon { [weak self] _ in
+            self?.completedUnitCount = 1
+        }
+    }
+
+}
+
+// MARK: - Task extension
+
+/**
+ Both Task<Value> and NSProgress operate compose over implicit trees, but their
+ ordering is reversed. You call map or flatMap on a Task to schedule follow-up
+ work, which looks a lot like chaining; a progress tree has a parent-child
+ approach. These are compatible: Task adopts progress instances given to it,
+ creating a root node implicitly used by chaining calls.
+ **/
+
+private let NSProgressTaskRootLockKey = "com_bignerdranch_Deferred_taskRootLock"
+
+extension NSProgress {
+
+    /// `true` if the progress is a wrapper progress created by `Task<Value>`
+    private var isTaskRoot: Bool {
+        return userInfo[NSProgressTaskRootLockKey] != nil
+    }
+
+    static func extendingRootIfNeeded<Future: FutureType>(for future: Future, progress: NSProgress) -> NSProgress {
+        if progress.isTaskRoot || progress === NSProgress.currentProgress() {
+            // Task<Value> has already taken care of this at a deeper level.
+            return progress
+        } else if let root = NSProgress.currentProgress().flatMap({ return $0.isTaskRoot ? $0 : nil }) {
+            // We're in a `extendingTask(unitCount:body:)` block, append it.
+            root.addChild(progress, for: future, withPendingUnitCount: 1)
+            return root
+        } else {
+            // Otherwise, wrap it up as a Task<Value>-marked progress.
+            return NSProgress(taskRootFor: future, progress: progress)
+        }
+    }
+
+    /// Create a progress for the root of an implicit
+    convenience init<Future: FutureType>(taskRootFor future: Future, progress: NSProgress) {
+        self.init(discreteWithCount: 1)
+        setUserInfoObject(NSLock(), forKey: NSProgressTaskRootLockKey)
+        addChild(progress, for: future, withPendingUnitCount: 1)
+    }
+
+}
+
+extension TaskType {
+
+    private func withRootProgress(@noescape body: NSProgress -> Void) -> NSProgress {
+        if let lock = progress.userInfo[NSProgressTaskRootLockKey] as? NSLock {
+            lock.lock()
+            defer { lock.unlock() }
+
+            body(progress)
+            return progress
+        } else {
+            let progress = NSProgress(taskRootFor: self, progress: self.progress)
+
+            body(progress)
+            return progress
+        }
+    }
+
+    /// Extend the progress of `self` to reflect an added operation of `cost`.
+    func extendingTask<Return>(unitCount cost: Int64, body: (Value) -> Return) -> (NSProgress, (Value) -> Return) {
+        let progress = withRootProgress { $0.totalUnitCount += cost }
+
+        return (progress, { [weak progress] (result) -> Return in
+            progress?.becomeCurrentWithPendingUnitCount(cost)
+            defer { progress?.resignCurrent() }
+            return body(result)
+        })
+    }
+
+}

--- a/Sources/Task/TaskType.swift
+++ b/Sources/Task/TaskType.swift
@@ -10,7 +10,7 @@
 import Deferred
 import Result
 #endif
-import Dispatch
+import Foundation
 
 /// A task is a future modelling the completion of some underlying operation,
 /// such as making a web request.
@@ -25,6 +25,11 @@ public protocol TaskType: FutureType {
     /// A type that represents the result of some asynchronous operation.
     associatedtype Value: ResultType
 
+    /// The progress of the task.
+    ///
+    /// `cancel()` will typically chain to this `progress`.
+    var progress: NSProgress { get }
+
     /// Attempt to cancel the underlying operation.
     ///
     /// An implementation should be a "best effort". There are several
@@ -35,4 +40,11 @@ public protocol TaskType: FutureType {
     ///
     /// - seealso: isFilled
     func cancel()
+}
+
+extension TaskType {
+    /// Attempt to cancel the underlying operation. This is a "best effort".
+    public func cancel() {
+        progress.cancel()
+    }
 }

--- a/Tests/Fixtures.swift
+++ b/Tests/Fixtures.swift
@@ -79,26 +79,21 @@ class CustomQueueTestCase: XCTestCase {
     }
 
     private(set) var queue: dispatch_queue_t!
-    private var specificPtr: UnsafeMutablePointer<Void>!
 
     override func setUp() {
         super.setUp()
 
         queue = dispatch_queue_create("Deferred test queue", DISPATCH_QUEUE_CONCURRENT)
-        specificPtr = malloc(0)
-        dispatch_queue_set_specific(queue, &Constants.key, specificPtr, nil)
+        dispatch_queue_set_specific(queue, &Constants.key, UnsafeMutablePointer(Unmanaged.passUnretained(self).toOpaque()), nil)
     }
 
     override func tearDown() {
         queue = nil
-        free(specificPtr)
-        specificPtr = nil
-
         super.tearDown()
     }
 
     func assertOnQueue(inFile file: StaticString = #file, atLine line: UInt = #line) {
-        XCTAssertEqual(dispatch_get_specific(&Constants.key), specificPtr, file: file, line: line)
+        XCTAssertEqual(dispatch_get_specific(&Constants.key), UnsafeMutablePointer(Unmanaged.passUnretained(self).toOpaque()), file: file, line: line)
     }
     
 }

--- a/Tests/FutureCustomExecutorTests.swift
+++ b/Tests/FutureCustomExecutorTests.swift
@@ -30,7 +30,6 @@ class FutureCustomExecutorTests: CustomExecutorTestCase {
         d.fill(())
 
         waitForExpectationsWithTimeout(TestTimeout, handler: nil)
-        assertExecutorCalled(1)
     }
 
     func testMap() {
@@ -47,7 +46,6 @@ class FutureCustomExecutorTests: CustomExecutorTestCase {
         marker.fill(())
 
         waitForExpectationsWithTimeout(TestTimeout, handler: nil)
-        assertExecutorCalled(2)
     }
 
     func testFlatMap() {
@@ -64,7 +62,6 @@ class FutureCustomExecutorTests: CustomExecutorTestCase {
         marker.fill(())
 
         waitForExpectationsWithTimeout(TestTimeout, handler: nil)
-        assertExecutorCalled(3)
     }
 
 }

--- a/Tests/TaskTests.swift
+++ b/Tests/TaskTests.swift
@@ -101,7 +101,7 @@ class TaskTests: XCTestCase {
 
         let afterExpectation = expectationWithDescription("flatMapped task is cancelled")
         let afterTask: Task<String> = beforeTask.flatMap { _ in
-            return Task(Future(), cancellation: afterExpectation.fulfill)
+            return Task(future: Future(), cancellation: afterExpectation.fulfill)
         }
 
         afterTask.cancel()
@@ -180,7 +180,6 @@ class TaskCustomExecutorTests: CustomExecutorTestCase {
         d.succeed(1)
 
         waitForExpectationsWithTimeout(TestTimeout, handler: nil)
-        assertExecutorCalledAtLeastOnce()
     }
 
     func testUponFailure() {
@@ -194,7 +193,6 @@ class TaskCustomExecutorTests: CustomExecutorTestCase {
         d.fail(Error.First)
 
         waitForExpectationsWithTimeout(TestTimeout, handler: nil)
-        assertExecutorCalledAtLeastOnce()
     }
 
     func testThatThrowingMapSubstitutesWithError() {
@@ -217,7 +215,6 @@ class TaskCustomExecutorTests: CustomExecutorTestCase {
         }
 
         waitForExpectationsWithTimeout(TestTimeout, handler: nil)
-        assertExecutorCalled(3)
     }
 
     func testThatFlatMapForwardsCancellationToSubsequentTask() {
@@ -225,13 +222,12 @@ class TaskCustomExecutorTests: CustomExecutorTestCase {
 
         let afterExpectation = expectationWithDescription("flatMapped task is cancelled")
         let afterTask: Task<String> = beforeTask.flatMap(upon: executor) { _ in
-            return Task(Future(), cancellation: afterExpectation.fulfill)
+            return Task(future: Future(), cancellation: afterExpectation.fulfill)
         }
 
         afterTask.cancel()
 
         waitForExpectationsWithTimeout(TestTimeout, handler: nil)
-        assertExecutorCalled(1)
     }
 
     func testThatThrowingFlatMapSubstitutesWithError() {
@@ -248,7 +244,6 @@ class TaskCustomExecutorTests: CustomExecutorTestCase {
         }
 
         waitForExpectationsWithTimeout(TestTimeout, handler: nil)
-        assertExecutorCalledAtLeastOnce()
     }
 
     func testThatRecoverMapsFailures() {
@@ -269,7 +264,6 @@ class TaskCustomExecutorTests: CustomExecutorTestCase {
         }
 
         waitForExpectationsWithTimeout(TestTimeout, handler: nil)
-        assertExecutorCalled(1)
     }
 
 }
@@ -337,7 +331,7 @@ class TaskCustomQueueTests: CustomQueueTestCase {
         let afterExpectation = expectationWithDescription("flatMapped task is cancelled")
         let afterTask = beforeTask.flatMap(upon: queue) { _ -> Task<String> in
             self.assertOnQueue()
-            return Task(Future(), cancellation: afterExpectation.fulfill)
+            return Task(future: Future(), cancellation: afterExpectation.fulfill)
         }
 
         afterTask.cancel()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->

#### What's in this pull request?

Reworks Task (see #98) to have progress reporting.

The primary semantics change that I can figure is that `cancel` handlers are executed asynchronously (all cancellation for a given progress tree is issued synchronously, though), which is in line with our "best attempt" recommendation.

Since there *are* semantics changes, I would like it to be reviewed separately.

#### Testing

See semantics changes notes above.

Testing for this also uncovered some racing that occurred on Travis (or similarly constrained cases), and has been addressed.

#### API Changes

Additive.

