### PR TITLE
Deferred for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   global:
   - NSUnbufferedIO=YES
   matrix:
-  - JOB=Test-macOS DESTINATION='platform=macOS' ACTION=test
+  - JOB=Test-macOS ACTION=test
 matrix:
   include:
   - env: JOB=Test-iOS DEVICE='iPhone 6s (10.0)' PLATFORM='iOS Simulator' ACTION=test
@@ -30,6 +30,8 @@ before_script:
 script:
 - if [[ $DESTINATION ]]; then
     xcodebuild $ACTION -scheme Deferred -destination "$DESTINATION" | xcpretty -c;
+  else
+    swift test;
   fi
 after_success:
 - if [[ "$JOB" == "Misc" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,23 @@ matrix:
   - env: JOB=Test-iOS DEVICE='iPhone 6s (10.0)' PLATFORM='iOS Simulator' ACTION=test
   - env: JOB=Build-tvOS DESTINATION='platform=tvOS Simulator,name=Apple TV 1080p' ACTION=build
   - env: JOB=Build-watchOS DESTINATION='platform=watchOS Simulator,name=Apple Watch - 42mm' ACTION=build
+  - os: linux
+    dist: trusty
+    sudo: required
+    addons:
+      apt:
+        packages:
+        - clang-3.8
+        - libicu-dev
+    env: JOB=Test-Linux COMPILER=clang-3.8
+    before_install:
+    - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
+    install:
+    - wget https://swift.org/builds/swift-3.0-release/ubuntu1404/swift-3.0-RELEASE/swift-3.0-RELEASE-ubuntu14.04.tar.gz
+    - tar xzf swift-3.0-RELEASE-ubuntu14.04.tar.gz
+    - export PATH=swift-3.0-RELEASE-ubuntu14.04/usr/bin:$PATH
+    script:
+    - swift test
   - env: JOB=Misc
     script:
     - bundle exec pod lib lint --quick
@@ -40,4 +57,6 @@ after_success:
     sleep 5;
   fi
 after_failure:
-- cat ~/Library/Developer/Xcode/DerivedData/Deferred-*/Logs/Test/*/Session-DeferredTests-*.log
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    cat ~/Library/Developer/Xcode/DerivedData/Deferred-*/Logs/Test/*/Session-DeferredTests-*.log;
+  fi

--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -35,19 +35,19 @@
 		DB524CEA1D85205400DDF16D /* TaskMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CB01D85200C00DDF16D /* TaskMap.swift */; };
 		DB524CEB1D85205400DDF16D /* TaskProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CB11D85200C00DDF16D /* TaskProgress.swift */; };
 		DB524CEC1D85205400DDF16D /* TaskRecover.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CB21D85200C00DDF16D /* TaskRecover.swift */; };
-		DB524CED1D85206100DDF16D /* BlockCancellableTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CB41D85200C00DDF16D /* BlockCancellableTaskTests.swift */; };
-		DB524CEE1D85206100DDF16D /* DeferredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CB51D85200C00DDF16D /* DeferredTests.swift */; };
-		DB524CEF1D85206100DDF16D /* ExistentialFutureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CB61D85200C00DDF16D /* ExistentialFutureTests.swift */; };
-		DB524CF01D85206100DDF16D /* Fixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CB71D85200C00DDF16D /* Fixtures.swift */; };
-		DB524CF11D85206100DDF16D /* FutureCustomExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CB81D85200C00DDF16D /* FutureCustomExecutorTests.swift */; };
-		DB524CF21D85206100DDF16D /* IgnoringFutureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CB91D85200C00DDF16D /* IgnoringFutureTests.swift */; };
-		DB524CF31D85206100DDF16D /* LockProtectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CBB1D85200C00DDF16D /* LockProtectedTests.swift */; };
-		DB524CF41D85206100DDF16D /* ReadWriteLockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CBC1D85200C00DDF16D /* ReadWriteLockTests.swift */; };
-		DB524CF51D85206100DDF16D /* ResultRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CBD1D85200C00DDF16D /* ResultRecoveryTests.swift */; };
-		DB524CF61D85206100DDF16D /* TaskAccumulatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CBE1D85200C00DDF16D /* TaskAccumulatorTests.swift */; };
-		DB524CF71D85206100DDF16D /* TaskResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CBF1D85200C00DDF16D /* TaskResultTests.swift */; };
-		DB524CF81D85206100DDF16D /* TaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CC01D85200C00DDF16D /* TaskTests.swift */; };
-		DB524CF91D85206100DDF16D /* VoidResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CC11D85200C00DDF16D /* VoidResultTests.swift */; };
+		DB55F1FE1D96968E00FC1439 /* Fixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1EE1D96968E00FC1439 /* Fixtures.swift */; };
+		DB55F1FF1D96968E00FC1439 /* DeferredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1F01D96968E00FC1439 /* DeferredTests.swift */; };
+		DB55F2001D96968E00FC1439 /* ExistentialFutureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1F11D96968E00FC1439 /* ExistentialFutureTests.swift */; };
+		DB55F2011D96968E00FC1439 /* FutureCustomExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1F21D96968E00FC1439 /* FutureCustomExecutorTests.swift */; };
+		DB55F2021D96968E00FC1439 /* IgnoringFutureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1F31D96968E00FC1439 /* IgnoringFutureTests.swift */; };
+		DB55F2031D96968E00FC1439 /* LockingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1F41D96968E00FC1439 /* LockingTests.swift */; };
+		DB55F2041D96968E00FC1439 /* ProtectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1F51D96968E00FC1439 /* ProtectedTests.swift */; };
+		DB55F2051D96968E00FC1439 /* ResultRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1F71D96968E00FC1439 /* ResultRecoveryTests.swift */; };
+		DB55F2061D96968E00FC1439 /* TaskResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1F81D96968E00FC1439 /* TaskResultTests.swift */; };
+		DB55F2071D96968E00FC1439 /* VoidResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1F91D96968E00FC1439 /* VoidResultTests.swift */; };
+		DB55F2081D96968E00FC1439 /* TaskGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1FB1D96968E00FC1439 /* TaskGroupTests.swift */; };
+		DB55F2091D96968E00FC1439 /* TaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1FC1D96968E00FC1439 /* TaskTests.swift */; };
+		DB55F20A1D96968E00FC1439 /* TaskWorkItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1FD1D96968E00FC1439 /* TaskWorkItemTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -96,21 +96,21 @@
 		DB524CB01D85200C00DDF16D /* TaskMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskMap.swift; sourceTree = "<group>"; };
 		DB524CB11D85200C00DDF16D /* TaskProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskProgress.swift; sourceTree = "<group>"; };
 		DB524CB21D85200C00DDF16D /* TaskRecover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRecover.swift; sourceTree = "<group>"; };
-		DB524CB41D85200C00DDF16D /* BlockCancellableTaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockCancellableTaskTests.swift; sourceTree = "<group>"; };
-		DB524CB51D85200C00DDF16D /* DeferredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredTests.swift; sourceTree = "<group>"; };
-		DB524CB61D85200C00DDF16D /* ExistentialFutureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistentialFutureTests.swift; sourceTree = "<group>"; };
-		DB524CB71D85200C00DDF16D /* Fixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fixtures.swift; sourceTree = "<group>"; };
-		DB524CB81D85200C00DDF16D /* FutureCustomExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FutureCustomExecutorTests.swift; sourceTree = "<group>"; };
-		DB524CB91D85200C00DDF16D /* IgnoringFutureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoringFutureTests.swift; sourceTree = "<group>"; };
 		DB524CBA1D85200C00DDF16D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		DB524CBB1D85200C00DDF16D /* LockProtectedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockProtectedTests.swift; sourceTree = "<group>"; };
-		DB524CBC1D85200C00DDF16D /* ReadWriteLockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWriteLockTests.swift; sourceTree = "<group>"; };
-		DB524CBD1D85200C00DDF16D /* ResultRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultRecoveryTests.swift; sourceTree = "<group>"; };
-		DB524CBE1D85200C00DDF16D /* TaskAccumulatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskAccumulatorTests.swift; sourceTree = "<group>"; };
-		DB524CBF1D85200C00DDF16D /* TaskResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskResultTests.swift; sourceTree = "<group>"; };
-		DB524CC01D85200C00DDF16D /* TaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskTests.swift; sourceTree = "<group>"; };
-		DB524CC11D85200C00DDF16D /* VoidResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoidResultTests.swift; sourceTree = "<group>"; };
 		DB524CFD1D85489500DDF16D /* Atomics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Atomics.h; path = include/Atomics.h; sourceTree = "<group>"; };
+		DB55F1EE1D96968E00FC1439 /* Fixtures.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Fixtures.swift; path = Sources/TestSupport/Fixtures.swift; sourceTree = SOURCE_ROOT; };
+		DB55F1F01D96968E00FC1439 /* DeferredTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeferredTests.swift; sourceTree = "<group>"; };
+		DB55F1F11D96968E00FC1439 /* ExistentialFutureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExistentialFutureTests.swift; sourceTree = "<group>"; };
+		DB55F1F21D96968E00FC1439 /* FutureCustomExecutorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureCustomExecutorTests.swift; sourceTree = "<group>"; };
+		DB55F1F31D96968E00FC1439 /* IgnoringFutureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IgnoringFutureTests.swift; sourceTree = "<group>"; };
+		DB55F1F41D96968E00FC1439 /* LockingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockingTests.swift; sourceTree = "<group>"; };
+		DB55F1F51D96968E00FC1439 /* ProtectedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProtectedTests.swift; sourceTree = "<group>"; };
+		DB55F1F71D96968E00FC1439 /* ResultRecoveryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultRecoveryTests.swift; sourceTree = "<group>"; };
+		DB55F1F81D96968E00FC1439 /* TaskResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskResultTests.swift; sourceTree = "<group>"; };
+		DB55F1F91D96968E00FC1439 /* VoidResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoidResultTests.swift; sourceTree = "<group>"; };
+		DB55F1FB1D96968E00FC1439 /* TaskGroupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskGroupTests.swift; sourceTree = "<group>"; };
+		DB55F1FC1D96968E00FC1439 /* TaskTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskTests.swift; sourceTree = "<group>"; };
+		DB55F1FD1D96968E00FC1439 /* TaskWorkItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskWorkItemTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -226,19 +226,10 @@
 		DB524CB31D85200C00DDF16D /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				DB524CB41D85200C00DDF16D /* BlockCancellableTaskTests.swift */,
-				DB524CB51D85200C00DDF16D /* DeferredTests.swift */,
-				DB524CB61D85200C00DDF16D /* ExistentialFutureTests.swift */,
-				DB524CB71D85200C00DDF16D /* Fixtures.swift */,
-				DB524CB81D85200C00DDF16D /* FutureCustomExecutorTests.swift */,
-				DB524CB91D85200C00DDF16D /* IgnoringFutureTests.swift */,
-				DB524CBB1D85200C00DDF16D /* LockProtectedTests.swift */,
-				DB524CBC1D85200C00DDF16D /* ReadWriteLockTests.swift */,
-				DB524CBD1D85200C00DDF16D /* ResultRecoveryTests.swift */,
-				DB524CBE1D85200C00DDF16D /* TaskAccumulatorTests.swift */,
-				DB524CBF1D85200C00DDF16D /* TaskResultTests.swift */,
-				DB524CC01D85200C00DDF16D /* TaskTests.swift */,
-				DB524CC11D85200C00DDF16D /* VoidResultTests.swift */,
+				DB55F1EF1D96968E00FC1439 /* DeferredTests */,
+				DB55F1F61D96968E00FC1439 /* ResultTests */,
+				DB55F1FA1D96968E00FC1439 /* TaskTests */,
+				DB55F1EE1D96968E00FC1439 /* Fixtures.swift */,
 				DB524CBA1D85200C00DDF16D /* Info.plist */,
 			);
 			path = Tests;
@@ -250,6 +241,39 @@
 				DB524CFD1D85489500DDF16D /* Atomics.h */,
 			);
 			path = Atomics;
+			sourceTree = "<group>";
+		};
+		DB55F1EF1D96968E00FC1439 /* DeferredTests */ = {
+			isa = PBXGroup;
+			children = (
+				DB55F1F01D96968E00FC1439 /* DeferredTests.swift */,
+				DB55F1F11D96968E00FC1439 /* ExistentialFutureTests.swift */,
+				DB55F1F21D96968E00FC1439 /* FutureCustomExecutorTests.swift */,
+				DB55F1F31D96968E00FC1439 /* IgnoringFutureTests.swift */,
+				DB55F1F41D96968E00FC1439 /* LockingTests.swift */,
+				DB55F1F51D96968E00FC1439 /* ProtectedTests.swift */,
+			);
+			path = DeferredTests;
+			sourceTree = "<group>";
+		};
+		DB55F1F61D96968E00FC1439 /* ResultTests */ = {
+			isa = PBXGroup;
+			children = (
+				DB55F1F71D96968E00FC1439 /* ResultRecoveryTests.swift */,
+				DB55F1F81D96968E00FC1439 /* TaskResultTests.swift */,
+				DB55F1F91D96968E00FC1439 /* VoidResultTests.swift */,
+			);
+			path = ResultTests;
+			sourceTree = "<group>";
+		};
+		DB55F1FA1D96968E00FC1439 /* TaskTests */ = {
+			isa = PBXGroup;
+			children = (
+				DB55F1FB1D96968E00FC1439 /* TaskGroupTests.swift */,
+				DB55F1FC1D96968E00FC1439 /* TaskTests.swift */,
+				DB55F1FD1D96968E00FC1439 /* TaskWorkItemTests.swift */,
+			);
+			path = TaskTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -397,19 +421,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DB524CEE1D85206100DDF16D /* DeferredTests.swift in Sources */,
-				DB524CF71D85206100DDF16D /* TaskResultTests.swift in Sources */,
-				DB524CF31D85206100DDF16D /* LockProtectedTests.swift in Sources */,
-				DB524CF91D85206100DDF16D /* VoidResultTests.swift in Sources */,
-				DB524CF81D85206100DDF16D /* TaskTests.swift in Sources */,
-				DB524CF41D85206100DDF16D /* ReadWriteLockTests.swift in Sources */,
-				DB524CED1D85206100DDF16D /* BlockCancellableTaskTests.swift in Sources */,
-				DB524CF21D85206100DDF16D /* IgnoringFutureTests.swift in Sources */,
-				DB524CF01D85206100DDF16D /* Fixtures.swift in Sources */,
-				DB524CF11D85206100DDF16D /* FutureCustomExecutorTests.swift in Sources */,
-				DB524CEF1D85206100DDF16D /* ExistentialFutureTests.swift in Sources */,
-				DB524CF61D85206100DDF16D /* TaskAccumulatorTests.swift in Sources */,
-				DB524CF51D85206100DDF16D /* ResultRecoveryTests.swift in Sources */,
+				DB55F2041D96968E00FC1439 /* ProtectedTests.swift in Sources */,
+				DB55F2061D96968E00FC1439 /* TaskResultTests.swift in Sources */,
+				DB55F1FE1D96968E00FC1439 /* Fixtures.swift in Sources */,
+				DB55F2051D96968E00FC1439 /* ResultRecoveryTests.swift in Sources */,
+				DB55F2091D96968E00FC1439 /* TaskTests.swift in Sources */,
+				DB55F1FF1D96968E00FC1439 /* DeferredTests.swift in Sources */,
+				DB55F2071D96968E00FC1439 /* VoidResultTests.swift in Sources */,
+				DB55F2081D96968E00FC1439 /* TaskGroupTests.swift in Sources */,
+				DB55F2011D96968E00FC1439 /* FutureCustomExecutorTests.swift in Sources */,
+				DB55F2001D96968E00FC1439 /* ExistentialFutureTests.swift in Sources */,
+				DB55F2021D96968E00FC1439 /* IgnoringFutureTests.swift in Sources */,
+				DB55F20A1D96968E00FC1439 /* TaskWorkItemTests.swift in Sources */,
+				DB55F2031D96968E00FC1439 /* LockingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 //  Deferred
 //
 //  Created by Zachary Waldowski on 12/7/15.
-//  Copyright © 2014-2015 Big Nerd Ranch. Licensed under MIT.
+//  Copyright © 2014-2016 Big Nerd Ranch. Licensed under MIT.
 //
 
 import PackageDescription
@@ -19,6 +19,28 @@ let package = Package(
         Target(name: "Task", dependencies: [
             .Target(name: "Deferred"),
             .Target(name: "Result")
-        ])
+        ]),
+
+        Target(name: "TestSupport", dependencies: [
+            .Target(name: "Deferred"),
+            .Target(name: "Result"),
+            .Target(name: "Task"),
+        ]),
+
+        Target(name: "DeferredTests", dependencies: [
+            .Target(name: "TestSupport"),
+            .Target(name: "Deferred"),
+        ]),
+        Target(name: "ResultTests", dependencies: [
+            .Target(name: "TestSupport"),
+            .Target(name: "Result"),
+        ]),
+        Target(name: "TaskTests", dependencies: [
+            .Target(name: "TestSupport"),
+            .Target(name: "Task"),
+        ]),
     ]
 )
+
+let dylib = Product(name: "Deferred", type: .Library(.Dynamic), modules: "Deferred", "Result", "Task")
+products.append(dylib)

--- a/Sources/Deferred/Executor.swift
+++ b/Sources/Deferred/Executor.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2014-2016 Big Nerd Ranch. All rights reserved.
 //
 
+import Dispatch
+import CoreFoundation
 import Foundation
 
 /// An executor calls closures submitted to it in first-in, first-out order,
@@ -121,7 +123,11 @@ extension OperationQueue: Executor {
 /// of the run loop.
 extension CFRunLoop: Executor {
     @nonobjc public func submit(_ body: @escaping() -> Void) {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         CFRunLoopPerformBlock(self, CFRunLoopMode.defaultMode.rawValue, body)
+        #else
+        CFRunLoopPerformBlock(self, kCFRunLoopDefaultMode, body)
+        #endif
         CFRunLoopWakeUp(self)
     }
 }

--- a/Sources/Task/IgnoringTask.swift
+++ b/Sources/Task/IgnoringTask.swift
@@ -10,7 +10,8 @@
 import Deferred
 import Result
 #endif
-import Foundation
+
+import Dispatch
 
 /// A `FutureProtocol` whose determined element is that of a `Base` future passed
 /// through a transform function returning `NewValue`. This value is computed
@@ -66,6 +67,10 @@ extension Task {
             result.withValues(ifLeft: TaskResult.failure, ifRight: { _ in TaskResult.success() })
         })
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         return Task<Void>(future: future, progress: progress)
+#else
+        return Task<Void>(future: future, cancellation: cancel)
+#endif
     }
 }

--- a/Sources/Task/TaskCollections.swift
+++ b/Sources/Task/TaskCollections.swift
@@ -10,7 +10,12 @@
 import Deferred
 import Result
 #endif
-import Foundation
+
+import Dispatch
+
+// TODO: XPLAT
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+import class Foundation.Progress
 
 extension Collection where Iterator.Element: FutureProtocol, Iterator.Element.Value: Either, Iterator.Element.Value.Left == Error {
     /// Compose a number of tasks into a single notifier task.
@@ -50,3 +55,4 @@ extension Collection where Iterator.Element: FutureProtocol, Iterator.Element.Va
         return Task(coalescingDeferred, progress: outerProgress)
     }
 }
+#endif

--- a/Sources/Task/TaskProgress.swift
+++ b/Sources/Task/TaskProgress.swift
@@ -6,11 +6,13 @@
 //  Copyright © 2016 Big Nerd Ranch. All rights reserved.
 //
 
-import Foundation
 #if SWIFT_PACKAGE
 import Result
 import Deferred
 #endif
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+import Foundation
 
 // MARK: - Backports
 
@@ -250,3 +252,5 @@ extension Task {
         }
     }
 }
+
+#endif

--- a/Sources/TestSupport/Fixtures.swift
+++ b/Sources/TestSupport/Fixtures.swift
@@ -7,12 +7,13 @@
 //
 
 import XCTest
-@testable import Deferred
+import Deferred
 #if SWIFT_PACKAGE
 import Result
+import Task
 #endif
 
-enum Error: Swift.Error {
+enum TestError: Error {
     case first
     case second
     case third

--- a/Sources/TestSupport/Fixtures.swift
+++ b/Sources/TestSupport/Fixtures.swift
@@ -13,6 +13,9 @@ import Result
 import Task
 #endif
 
+import Dispatch
+import typealias Foundation.TimeInterval
+
 enum TestError: Error {
     case first
     case second
@@ -20,28 +23,38 @@ enum TestError: Error {
 }
 
 extension XCTestCase {
-    func waitForTaskToComplete<T>(_ task: Task<T>) -> TaskResult<T> {
+    func waitForTaskToComplete<T>(_ task: Task<T>, file: StaticString = #file, line: UInt = #line) -> TaskResult<T> {
         let expectation = self.expectation(description: "task completed")
         var result: TaskResult<T>?
         task.upon(.main) { [weak expectation] in
             result = $0
             expectation?.fulfill()
         }
-        waitForExpectations()
+        waitForExpectations(file: file, line: line)
 
         return result!
     }
 
-    func waitForExpectations() {
-        waitForExpectations(timeout: 10, handler: nil)
+    func waitForExpectations(file: StaticString = #file, line: UInt = #line) {
+        let timeout: TimeInterval = 10
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+            waitForExpectations(timeout: timeout, handler: nil)
+        #else
+            waitForExpectations(timeout: timeout, file: file, line: line, handler: nil)
+        #endif
     }
 
-    func waitForExpectationsShort() {
-        waitForExpectations(timeout: 2, handler: nil)
+    func waitForExpectationsShort(file: StaticString = #file, line: UInt = #line) {
+        let timeout: TimeInterval = 3
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+            waitForExpectations(timeout: timeout, handler: nil)
+        #else
+            waitForExpectations(timeout: timeout, file: file, line: line, handler: nil)
+        #endif
     }
 
     func afterDelay(upon queue: DispatchQueue = .main, execute body: @escaping() -> ()) {
-        queue.asyncAfter(deadline: .now() + 0.1, execute: body)
+        queue.asyncAfter(deadline: .now() + 0.15, execute: body)
     }
 }
 

--- a/Tests/DeferredTests/DeferredTests.swift
+++ b/Tests/DeferredTests/DeferredTests.swift
@@ -8,14 +8,17 @@
 
 import XCTest
 @testable import Deferred
+#if SWIFT_PACKAGE
+@testable import TestSupport
+#endif
 
 class DeferredTests: XCTestCase {
-    
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
@@ -149,10 +152,10 @@ class DeferredTests: XCTestCase {
 
         waitForExpectations()
     }
-    
+
     func testUponMainQueueCalledWhenFilled() {
         let d = Deferred<Int>()
-        
+
         let expectation = self.expectation(description: "upon block called on main queue")
         d.upon(.main) { value in
             XCTAssertTrue(Thread.isMainThread)
@@ -160,7 +163,7 @@ class DeferredTests: XCTestCase {
             XCTAssertEqual(d.value, 1)
             expectation.fulfill()
         }
-        
+
         d.fill(with: 1)
         waitForExpectationsShort()
     }
@@ -294,7 +297,7 @@ class DeferredTests: XCTestCase {
 
         waitForExpectationsShort()
     }
-    
+
     func testDeferredOptionalBehavesCorrectly() {
         let d = Deferred<Optional<Int>>(filledWith: .none)
 
@@ -311,10 +314,10 @@ class DeferredTests: XCTestCase {
             XCTAssert($0 == .none)
             afterExpectation.fulfill()
         }
-        
+
         waitForExpectationsShort()
     }
-    
+
     func testIsFilledCanBeCalledMultipleTimesNotFilled() {
         let d = Deferred<Int>()
         XCTAssertFalse(d.isFilled)

--- a/Tests/DeferredTests/ExistentialFutureTests.swift
+++ b/Tests/DeferredTests/ExistentialFutureTests.swift
@@ -8,6 +8,9 @@
 
 import XCTest
 @testable import Deferred
+#if SWIFT_PACKAGE
+@testable import TestSupport
+#endif
 
 class ExistentialFutureTests: XCTestCase {
 

--- a/Tests/DeferredTests/ExistentialFutureTests.swift
+++ b/Tests/DeferredTests/ExistentialFutureTests.swift
@@ -14,6 +14,16 @@ import XCTest
 
 class ExistentialFutureTests: XCTestCase {
 
+    static var allTests : [(String, (ExistentialFutureTests) -> () throws -> Void)] {
+        return [
+            ("testFilledAnyFutureWaitAlwaysReturns", testFilledAnyFutureWaitAlwaysReturns),
+            ("testAnyWaitWithTimeout", testAnyWaitWithTimeout),
+            ("testFilledAnyFutureUpon", testFilledAnyFutureUpon),
+            ("testUnfilledAnyUponCalledWhenFilled", testUnfilledAnyUponCalledWhenFilled),
+            ("testFillAndIsFilledPostcondition", testFillAndIsFilledPostcondition),
+        ]
+    }
+
     var anyFuture: Future<Int>!
 
     override func tearDown() {

--- a/Tests/DeferredTests/FutureCustomExecutorTests.swift
+++ b/Tests/DeferredTests/FutureCustomExecutorTests.swift
@@ -7,7 +7,10 @@
 //
 
 import XCTest
-import Deferred
+@testable import Deferred
+#if SWIFT_PACKAGE
+@testable import TestSupport
+#endif
 
 class FutureCustomExecutorTests: CustomExecutorTestCase {
     func testUpon() {

--- a/Tests/DeferredTests/FutureCustomExecutorTests.swift
+++ b/Tests/DeferredTests/FutureCustomExecutorTests.swift
@@ -13,6 +13,15 @@ import XCTest
 #endif
 
 class FutureCustomExecutorTests: CustomExecutorTestCase {
+
+    static var allTests : [(String, (FutureCustomExecutorTests) -> () throws -> Void)] {
+        return [
+            ("testUpon", testUpon),
+            ("testMap", testMap),
+            ("testAndThen", testAndThen),
+        ]
+    }
+
     func testUpon() {
         let d = Deferred<Void>()
 

--- a/Tests/DeferredTests/IgnoringFutureTests.swift
+++ b/Tests/DeferredTests/IgnoringFutureTests.swift
@@ -14,6 +14,13 @@ import XCTest
 
 class IgnoringFutureTests: XCTestCase {
 
+    static var allTests : [(String, (IgnoringFutureTests) -> () throws -> Void)] {
+        return [
+            ("testWaitWithTimeout", testWaitWithTimeout),
+            ("testIgnoredUponCalledWhenFilled", testIgnoredUponCalledWhenFilled),
+        ]
+    }
+
     var future: IgnoringFuture<Deferred<Int>>!
 
     override func tearDown() {

--- a/Tests/DeferredTests/IgnoringFutureTests.swift
+++ b/Tests/DeferredTests/IgnoringFutureTests.swift
@@ -8,6 +8,9 @@
 
 import XCTest
 @testable import Deferred
+#if SWIFT_PACKAGE
+@testable import TestSupport
+#endif
 
 class IgnoringFutureTests: XCTestCase {
 

--- a/Tests/DeferredTests/LockingTests.swift
+++ b/Tests/DeferredTests/LockingTests.swift
@@ -9,6 +9,9 @@
 import XCTest
 import Deferred
 import Atomics
+#if SWIFT_PACKAGE
+@testable import TestSupport
+#endif
 
 func timeIntervalSleep(_ duration: TimeInterval) {
     usleep(useconds_t(duration * TimeInterval(USEC_PER_SEC)))
@@ -66,7 +69,7 @@ class LockingTests: XCTestCase {
 
         queue = DispatchQueue(label: "LockingTests", attributes: .concurrent)
     }
-    
+
     override func tearDown() {
         queue = nil
 
@@ -157,7 +160,7 @@ class LockingTests: XCTestCase {
             for i in 32 ..< 64 {
                 startReader(i)
             }
-            
+
             waitForExpectationsShort()
         }
     }

--- a/Tests/DeferredTests/LockingTests.swift
+++ b/Tests/DeferredTests/LockingTests.swift
@@ -7,6 +7,9 @@
 //
 
 import XCTest
+import Dispatch
+import typealias Foundation.TimeInterval
+
 import Deferred
 import Atomics
 #if SWIFT_PACKAGE
@@ -14,40 +17,40 @@ import Atomics
 #endif
 
 func timeIntervalSleep(_ duration: TimeInterval) {
-    usleep(useconds_t(duration * TimeInterval(USEC_PER_SEC)))
-}
-
-class PerfTestThread: Thread {
-    let iters: Int
-    var lock: Locking
-    let joinLock = NSConditionLock(condition: 0)
-
-    init(lock: Locking, iters: Int) {
-        self.lock = lock
-        self.iters = iters
-        super.init()
-    }
-
-    override func main() {
-        joinLock.lock()
-        let doNothing: () -> () = {}
-        for i in 0 ..< iters {
-            if (i % 10) == 0 {
-                lock.withWriteLock(doNothing)
-            } else {
-                lock.withReadLock(doNothing)
-            }
-        }
-        joinLock.unlock(withCondition: 1)
-    }
-
-    func join() {
-        joinLock.lock(whenCondition: 1)
-        joinLock.unlock()
-    }
+    usleep(useconds_t(duration * TimeInterval(1_000_000)))
 }
 
 class LockingTests: XCTestCase {
+
+    static var allTests : [(String, (LockingTests) -> () throws -> Void)] {
+        let universalTests: [(String, (LockingTests) -> () throws -> Void)] = [
+            ("testMultipleConcurrentReaders", testMultipleConcurrentReaders),
+            ("testMultipleConcurrentWriters", testMultipleConcurrentWriters),
+            ("testSimultaneousReadersAndWriters", testSimultaneousReadersAndWriters),
+            ("testSingleThreadPerformanceGCDLockRead", testSingleThreadPerformanceGCDLockRead),
+            ("testSingleThreadPerformanceGCDLockWrite", testSingleThreadPerformanceGCDLockWrite),
+            ("testSingleThreadPerformanceSpinLockRead", testSingleThreadPerformanceSpinLockRead),
+            ("testSingleThreadPerformanceSpinLockWrite", testSingleThreadPerformanceSpinLockWrite),
+            ("testSingleThreadPerformanceCASSpinLockRead", testSingleThreadPerformanceCASSpinLockRead),
+            ("testSingleThreadPerformanceCASSpinLockWrite", testSingleThreadPerformanceCASSpinLockWrite),
+            ("testSingleThreadPerformancePThreadReadWriteLockRead", testSingleThreadPerformancePThreadReadWriteLockRead),
+            ("testSingleThreadPerformancePThreadReadWriteLockWrite", testSingleThreadPerformancePThreadReadWriteLockWrite),
+        ]
+
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        let appleTests: [(String, (LockingTests) -> () throws -> Void)] = [
+            ("test90PercentReads4ThreadsGCDLock", test90PercentReads4ThreadsGCDLock),
+            ("test90PercentReads4ThreadsSpinLock", test90PercentReads4ThreadsSpinLock),
+            ("test90PercentReads4ThreadsCASSpinLock", test90PercentReads4ThreadsCASSpinLock),
+            ("test90PercentReads4ThreadsPThreadReadWriteLock", test90PercentReads4ThreadsPThreadReadWriteLock),
+        ]
+
+            return universalTests + appleTests
+        #else
+            return universalTests
+        #endif
+    }
+
     var dispatchLock: DispatchLock!
     var spinLock: SpinLock!
     var casSpinLock: CASSpinLock!
@@ -127,7 +130,7 @@ class LockingTests: XCTestCase {
 
     func testSimultaneousReadersAndWriters() {
         for lock in allLocks {
-            var x: Int32 = 0
+            var x = UnsafeAtomicInt32()
 
             let startReader: (Int) -> () = { i in
                 let expectation = self.expectation(description: "reader \(i)")
@@ -135,7 +138,8 @@ class LockingTests: XCTestCase {
                     lock.withReadLock {
                         // make sure we get the value of x either before or after
                         // the writer runs, never a partway-through value
-                        XCTAssertTrue(x == 0 || x == 5)
+                        let result = x.load(order: .sequentiallyConsistent)
+                        XCTAssertTrue(result == 0 || result == 5)
                         expectation.fulfill()
                     }
                 }
@@ -150,7 +154,7 @@ class LockingTests: XCTestCase {
             queue.async {
                 lock.withWriteLock {
                     for _ in 0 ..< 5 {
-                        OSAtomicIncrement32Barrier(&x)
+                        x.add(1, order: .sequentiallyConsistent)
                         timeIntervalSleep(0.1)
                     }
                     expectation.fulfill()
@@ -183,20 +187,6 @@ class LockingTests: XCTestCase {
         }
     }
 
-    func measureLock90PercentReadsNThreads(_ lock: Locking, iters: Int, nthreads: Int) {
-        self.measure {
-            var threads: [PerfTestThread] = []
-            for _ in 0 ..< nthreads {
-                let t = PerfTestThread(lock: lock, iters: iters)
-                t.start()
-                threads.append(t)
-            }
-            for t in threads {
-                t.join()
-            }
-        }
-    }
-
     func testSingleThreadPerformanceGCDLockRead() {
         measureReadLockSingleThread(dispatchLock, iters: 250_000)
     }
@@ -225,6 +215,51 @@ class LockingTests: XCTestCase {
         measureWriteLockSingleThread(pthreadLock, iters: 250_000)
     }
 
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    class PerfTestThread: Thread {
+        let iters: Int
+        var lock: Locking
+        let joinLock = NSConditionLock(condition: 0)
+
+        init(lock: Locking, iters: Int) {
+            self.lock = lock
+            self.iters = iters
+            super.init()
+        }
+
+        override func main() {
+            joinLock.lock()
+            let doNothing: () -> () = {}
+            for i in 0 ..< iters {
+                if (i % 10) == 0 {
+                    lock.withWriteLock(doNothing)
+                } else {
+                    lock.withReadLock(doNothing)
+                }
+            }
+            joinLock.unlock(withCondition: 1)
+        }
+
+        func join() {
+            joinLock.lock(whenCondition: 1)
+            joinLock.unlock()
+        }
+    }
+
+    func measureLock90PercentReadsNThreads(_ lock: Locking, iters: Int, nthreads: Int) {
+        self.measure {
+            var threads: [PerfTestThread] = []
+            for _ in 0 ..< nthreads {
+                let t = PerfTestThread(lock: lock, iters: iters)
+                t.start()
+                threads.append(t)
+            }
+            for t in threads {
+                t.join()
+            }
+        }
+    }
+
     func test90PercentReads4ThreadsGCDLock() {
         measureLock90PercentReadsNThreads(dispatchLock, iters: 5_000, nthreads: 4)
     }
@@ -237,5 +272,6 @@ class LockingTests: XCTestCase {
     func test90PercentReads4ThreadsPThreadReadWriteLock() {
         measureLock90PercentReadsNThreads(pthreadLock, iters: 5_000, nthreads: 4)
     }
+    #endif
 
 }

--- a/Tests/DeferredTests/ProtectedTests.swift
+++ b/Tests/DeferredTests/ProtectedTests.swift
@@ -8,6 +8,9 @@
 
 import XCTest
 import Deferred
+#if SWIFT_PACKAGE
+@testable import TestSupport
+#endif
 
 class ProtectedTests: XCTestCase {
     var protected: Protected<(Date?, [Int])>!
@@ -19,7 +22,7 @@ class ProtectedTests: XCTestCase {
         protected = Protected(initialValue: (nil, []))
         queue = DispatchQueue(label: "ProtectedTests", attributes: .concurrent)
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()

--- a/Tests/DeferredTests/ProtectedTests.swift
+++ b/Tests/DeferredTests/ProtectedTests.swift
@@ -7,12 +7,22 @@
 //
 
 import XCTest
+import Dispatch
+import struct Foundation.Date
+
 import Deferred
 #if SWIFT_PACKAGE
 @testable import TestSupport
 #endif
 
 class ProtectedTests: XCTestCase {
+
+    static var allTests : [(String, (ProtectedTests) -> () throws -> Void)] {
+        return [
+            ("testConcurrentReadingWriting", testConcurrentReadingWriting)
+        ]
+    }
+
     var protected: Protected<(Date?, [Int])>!
     var queue: DispatchQueue!
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,29 @@
+//
+//  LinuxMain.swift
+//  DeferredTests
+//
+//  Created by Zachary Waldowski on 9/21/16.
+//  Copyright © 2016 Big Nerd Ranch. Licensed under MIT.
+//
+
+import XCTest
+@testable import DeferredTests
+@testable import ResultTests
+@testable import TaskTests
+
+XCTMain([
+    testCase(DeferredTests.allTests),
+    testCase(ExistentialFutureTests.allTests),
+    testCase(FutureCustomExecutorTests.allTests),
+    testCase(IgnoringFutureTests.allTests),
+    testCase(LockingTests.allTests),
+    testCase(ProtectedTests.allTests),
+
+    testCase(ResultRecoveryTests.allTests),
+    testCase(TaskResultTests.allTests),
+    testCase(VoidResultTests.allTests),
+
+    testCase(TaskGroupTests.allTests),
+    testCase(TaskTests.allTests),
+    testCase(TaskWorkItemTests.allTests),
+])

--- a/Tests/ResultTests/ResultRecoveryTests.swift
+++ b/Tests/ResultTests/ResultRecoveryTests.swift
@@ -17,6 +17,13 @@ import Deferred
 
 class ResultRecoveryTests: XCTestCase {
 
+    static var allTests : [(String, (ResultRecoveryTests) -> () throws -> Void)] {
+        return [
+            ("testInitWithFunctionProducesSuccesses", testInitWithFunctionProducesSuccesses),
+            ("testInitWithFunctionProducesFailures", testInitWithFunctionProducesFailures),
+        ]
+    }
+
     private typealias Result = TaskResult<String>
 
     private func tryIsSuccess(_ text: String?) throws -> String {

--- a/Tests/ResultTests/ResultRecoveryTests.swift
+++ b/Tests/ResultTests/ResultRecoveryTests.swift
@@ -10,6 +10,7 @@ import XCTest
 #if SWIFT_PACKAGE
 import Deferred
 @testable import Result
+@testable import TestSupport
 #else
 @testable import Deferred
 #endif
@@ -20,7 +21,7 @@ class ResultRecoveryTests: XCTestCase {
 
     private func tryIsSuccess(_ text: String?) throws -> String {
         guard let text = text, text == "success" else {
-            throw Error.first
+            throw TestError.first
         }
 
         return text
@@ -43,7 +44,7 @@ class ResultRecoveryTests: XCTestCase {
     func testInitWithFunctionProducesFailures() {
         let result = Result(from: failureFunction)
         XCTAssertNil(result.value)
-        XCTAssertEqual(result.error as? Error, .first)
+        XCTAssertEqual(result.error as? TestError, .first)
     }
 
 }

--- a/Tests/ResultTests/TaskResultTests.swift
+++ b/Tests/ResultTests/TaskResultTests.swift
@@ -1,5 +1,5 @@
 //
-//  ResultTests.swift
+//  TaskResultTests.swift
 //  DeferredTests
 //
 //  Created by Zachary Waldowski on 2/7/15.
@@ -10,16 +10,17 @@ import XCTest
 #if SWIFT_PACKAGE
 import Deferred
 @testable import Result
+@testable import TestSupport
 #else
 @testable import Deferred
 #endif
 
-class ResultTests: XCTestCase {
+class TaskResultTests: XCTestCase {
 
     private typealias Result = TaskResult<Int>
 
     private let aSuccessResult = Result.success(42)
-    private let aFailureResult = Result.failure(Error.first)
+    private let aFailureResult = Result.failure(TestError.first)
 
     func testDescriptionSuccess() {
         XCTAssertEqual(String(describing: aSuccessResult), String(42))
@@ -36,7 +37,7 @@ class ResultTests: XCTestCase {
     func testDebugDescriptionFailure() {
         let debugDescription1 = String(reflecting: aFailureResult)
         XCTAssert(debugDescription1.hasPrefix("failure("))
-        XCTAssert(debugDescription1.hasSuffix("Error.first)"))
+        XCTAssert(debugDescription1.hasSuffix("TestError.first)"))
     }
 
     func testSuccessExtract() {

--- a/Tests/ResultTests/TaskResultTests.swift
+++ b/Tests/ResultTests/TaskResultTests.swift
@@ -17,6 +17,21 @@ import Deferred
 
 class TaskResultTests: XCTestCase {
 
+    static var allTests : [(String, (TaskResultTests) -> () throws -> Void)] {
+        return [
+            ("testDescriptionSuccess", testDescriptionSuccess),
+            ("testDescriptionFailure", testDescriptionFailure),
+            ("testDebugDescriptionSuccess", testDebugDescriptionSuccess),
+            ("testDebugDescriptionFailure", testDebugDescriptionFailure),
+            ("testSuccessExtract", testSuccessExtract),
+            ("testFailureExtract", testFailureExtract),
+            ("testCoalesceSuccessValue", testCoalesceSuccessValue),
+            ("testCoalesceFailureValue", testCoalesceFailureValue),
+            ("testFlatCoalesceSuccess", testFlatCoalesceSuccess),
+            ("testFlatCoalesceFailure", testFlatCoalesceFailure)
+        ]
+    }
+
     private typealias Result = TaskResult<Int>
 
     private let aSuccessResult = Result.success(42)
@@ -37,7 +52,7 @@ class TaskResultTests: XCTestCase {
     func testDebugDescriptionFailure() {
         let debugDescription1 = String(reflecting: aFailureResult)
         XCTAssert(debugDescription1.hasPrefix("failure("))
-        XCTAssert(debugDescription1.hasSuffix("TestError.first)"))
+        XCTAssert(debugDescription1.hasSuffix("Error.first)"))
     }
 
     func testSuccessExtract() {

--- a/Tests/ResultTests/VoidResultTests.swift
+++ b/Tests/ResultTests/VoidResultTests.swift
@@ -10,6 +10,7 @@ import XCTest
 #if SWIFT_PACKAGE
 import Deferred
 @testable import Result
+@testable import TestSupport
 #else
 @testable import Deferred
 #endif
@@ -19,7 +20,7 @@ class VoidResultTests: XCTestCase {
     private typealias Result = TaskResult<Void>
 
     private let aSuccessResult = Result.success(())
-    private let aFailureResult = Result.failure(Error.first)
+    private let aFailureResult = Result.failure(TestError.first)
 
     func testDescriptionSuccess() {
         XCTAssertEqual(String(describing: aSuccessResult), "()")
@@ -36,7 +37,7 @@ class VoidResultTests: XCTestCase {
     func testDebugDescriptionFailure() {
         let debugDescription = String(reflecting: aFailureResult)
         XCTAssert(debugDescription.hasPrefix("failure("))
-        XCTAssert(debugDescription.hasSuffix("Error.first)"))
+        XCTAssert(debugDescription.hasSuffix("TestError.first)"))
     }
 
     func testExtract() {

--- a/Tests/ResultTests/VoidResultTests.swift
+++ b/Tests/ResultTests/VoidResultTests.swift
@@ -17,6 +17,16 @@ import Deferred
 
 class VoidResultTests: XCTestCase {
 
+    static var allTests : [(String, (VoidResultTests) -> () throws -> Void)] {
+        return [
+            ("testDescriptionSuccess", testDescriptionSuccess),
+            ("testDescriptionFailure", testDescriptionFailure),
+            ("testDebugDescriptionSuccess", testDebugDescriptionSuccess),
+            ("testDebugDescriptionFailure", testDebugDescriptionFailure),
+            ("testExtract", testExtract),
+        ]
+    }
+
     private typealias Result = TaskResult<Void>
 
     private let aSuccessResult = Result.success(())
@@ -37,7 +47,7 @@ class VoidResultTests: XCTestCase {
     func testDebugDescriptionFailure() {
         let debugDescription = String(reflecting: aFailureResult)
         XCTAssert(debugDescription.hasPrefix("failure("))
-        XCTAssert(debugDescription.hasSuffix("TestError.first)"))
+        XCTAssert(debugDescription.hasSuffix("Error.first)"))
     }
 
     func testExtract() {

--- a/Tests/TaskTests/TaskGroupTests.swift
+++ b/Tests/TaskTests/TaskGroupTests.swift
@@ -11,6 +11,7 @@ import XCTest
 import Result
 import Deferred
 @testable import Task
+@testable import TestSupport
 #else
 @testable import Deferred
 #endif
@@ -44,7 +45,7 @@ class TaskGroupTests: XCTestCase {
                 if i % 2 == 0 {
                     deferred.fill(with: .success(()))
                 } else {
-                    deferred.fill(with: .failure(Error.first))
+                    deferred.fill(with: .failure(TestError.first))
                 }
             }
         }

--- a/Tests/TaskTests/TaskGroupTests.swift
+++ b/Tests/TaskTests/TaskGroupTests.swift
@@ -7,6 +7,8 @@
 //
 
 import XCTest
+import Dispatch
+
 #if SWIFT_PACKAGE
 import Result
 import Deferred
@@ -17,6 +19,12 @@ import Deferred
 #endif
 
 class TaskGroupTests: XCTestCase {
+
+    static var allTests : [(String, (TaskGroupTests) -> () throws -> Void)] {
+        return [
+            ("testThatAllCompleteTaskWaitsForAllAccumulatedTasks", testThatAllCompleteTaskWaitsForAllAccumulatedTasks),
+        ]
+    }
 
     private let queue = DispatchQueue(label: "TaskGroupTests", attributes: .concurrent)
     private var accumulator: TaskGroup!

--- a/Tests/TaskTests/TaskTests.swift
+++ b/Tests/TaskTests/TaskTests.swift
@@ -11,6 +11,7 @@ import XCTest
 import Result
 import Deferred
 @testable import Task
+@testable import TestSupport
 #else
 @testable import Deferred
 #endif
@@ -31,7 +32,7 @@ private extension XCTestCase {
 
     @nonobjc var anyFinishedTask: Task<Int> { return Task(success: 42) }
 
-    @nonobjc var anyFailedTask: Task<Int> { return Task(failure: Error.first) }
+    @nonobjc var anyFailedTask: Task<Int> { return Task(failure: TestError.first) }
 
     @nonobjc func contrivedNextTask(for result: Int) -> Task<Int> {
         let d = Deferred<Task<Int>.Result>()
@@ -66,7 +67,7 @@ class TaskTests: CustomExecutorTestCase {
         task.uponSuccess(on: executor, execute: impossible)
         task.uponFailure(on: executor) { _ in expectation.fulfill() }
 
-        d.fail(with: Error.first)
+        d.fail(with: TestError.first)
 
         waitForExpectations()
         assertExecutorCalled(atLeast: 1)
@@ -75,11 +76,11 @@ class TaskTests: CustomExecutorTestCase {
     func testThatThrowingMapSubstitutesWithError() {
         let expectation = self.expectation(description: "mapped filled with error")
         let task: Task<String> = anyFinishedTask.map(upon: executor) { _ in
-            throw Error.second
+            throw TestError.second
         }
 
         task.upon(executor) {
-            XCTAssertEqual($0.error as? Error, .second)
+            XCTAssertEqual($0.error as? TestError, .second)
             expectation.fulfill()
         }
 
@@ -102,11 +103,11 @@ class TaskTests: CustomExecutorTestCase {
     func testThatThrowingAndThenSubstitutesWithError() {
         let expectation = self.expectation(description: "flatMapped task is cancelled")
         let task = anyFinishedTask.andThen(upon: executor) { _ -> Task<String> in
-            throw Error.second
+            throw TestError.second
         }
 
         task.uponFailure {
-            XCTAssertEqual($0 as? Error, .second)
+            XCTAssertEqual($0 as? TestError, .second)
             expectation.fulfill()
         }
 
@@ -122,7 +123,7 @@ class TaskTests: CustomExecutorTestCase {
             XCTAssertEqual($0.value, 42)
             expectation.fulfill()
         }
-        
+
         waitForExpectations()
         assertExecutorCalled(1)
     }
@@ -132,7 +133,7 @@ class TaskTests: CustomExecutorTestCase {
         let task: Task<String> = anyFailedTask.map(upon: executor, transform: impossible)
 
         task.upon {
-            XCTAssertEqual($0.error as? Error, .first)
+            XCTAssertEqual($0.error as? TestError, .first)
             expectation.fulfill()
         }
 

--- a/Tests/TaskTests/TaskWorkItemTests.swift
+++ b/Tests/TaskTests/TaskWorkItemTests.swift
@@ -7,6 +7,8 @@
 //
 
 import XCTest
+import Dispatch
+
 #if SWIFT_PACKAGE
 import Result
 import Deferred
@@ -17,6 +19,13 @@ import Deferred
 #endif
 
 class TaskWorkItemTests: XCTestCase {
+    static var allTests : [(String, (TaskWorkItemTests) -> () throws -> Void)] {
+        return [
+            ("testThatCancellingATaskAfterItStartsRunningIsANoop", testThatCancellingATaskAfterItStartsRunningIsANoop),
+            ("testThatCancellingBeforeATaskStartsProducesTheCancellationError", testThatCancellingBeforeATaskStartsProducesTheCancellationError),
+        ]
+    }
+
     private var queue: DispatchQueue!
 
     override func setUp() {

--- a/Tests/TaskTests/TaskWorkItemTests.swift
+++ b/Tests/TaskTests/TaskWorkItemTests.swift
@@ -1,5 +1,5 @@
 //
-//  BlockCancellationTests.swift
+//  TaskWorkItemTests.swift
 //  DeferredTests
 //
 //  Created by John Gallagher on 7/15/15.
@@ -11,11 +11,12 @@ import XCTest
 import Result
 import Deferred
 @testable import Task
+@testable import TestSupport
 #else
 @testable import Deferred
 #endif
 
-class BlockCancellationTests: XCTestCase {
+class TaskWorkItemTests: XCTestCase {
     private var queue: DispatchQueue!
 
     override func setUp() {
@@ -34,7 +35,7 @@ class BlockCancellationTests: XCTestCase {
         let startSemaphore = DispatchSemaphore(value: 0)
         let finishSemaphore = DispatchSemaphore(value: 0)
 
-        let task = Task<Int>(upon: queue, onCancel: Error.first) {
+        let task = Task<Int>(upon: queue, onCancel: TestError.first) {
             startSemaphore.signal()
             XCTAssertEqual(finishSemaphore.wait(timeout: .distantFuture), .success)
             return 1
@@ -56,13 +57,13 @@ class BlockCancellationTests: XCTestCase {
             _ = semaphore.wait(timeout: .distantFuture)
         }
 
-        let task = Task<Int>(upon: queue, onCancel: Error.second) { 1 }
+        let task = Task<Int>(upon: queue, onCancel: TestError.second) { 1 }
 
         task.cancel()
 
         let result = waitForTaskToComplete(task)
         semaphore.signal()
-        XCTAssertEqual(result.error as? Error, .second)
+        XCTAssertEqual(result.error as? TestError, .second)
     }
 
 }


### PR DESCRIPTION
#### What's in this pull request?

Completes #54. 

🐧🐧🐧

#### Testing

Tests that exercise Darwin-specific behavior are not executed on Linux.

Performance testing of `Locking` types are currently disabled on Linux due to some vagaries of `Foundation.Thread`'s implementation.

#### API Changes

On Linux, the `Progress` features of `Task` are disabled. Due to a compiler crash `Collection<Task>.allSucceeded()` is disabled. (#124)