### PR TITLE
Revamp locking types

### DIFF
--- a/Deferred.xcodeproj/xcshareddata/xcschemes/Deferred.xcscheme
+++ b/Deferred.xcodeproj/xcshareddata/xcschemes/Deferred.xcscheme
@@ -27,7 +27,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -60,6 +61,8 @@
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      enableThreadSanitizer = "YES"
+      stopOnEveryThreadSanitizerIssue = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>

--- a/Sources/Deferred/Locking.swift
+++ b/Sources/Deferred/Locking.swift
@@ -7,7 +7,7 @@
 //
 
 import Dispatch
-import Atomics
+import Foundation
 
 /// A type that mutually excludes execution of code such that only one unit of
 /// code is running at any given time. An implementing type may choose to have
@@ -53,171 +53,85 @@ protocol MaybeLocking: Locking {
     func withAttemptedReadLock<Return>(_ body: () -> Return) -> Return?
 }
 
-/// A locking construct using a counting semaphore from Grand Central Dispatch.
-/// This locking type behaves the same for both read and write locks.
+/// A variant lock backed by a platform type that attempts to allow waiters to
+/// block efficiently on contention. This locking type behaves the same for both
+/// read and write locks.
 ///
-/// The semaphore lock performs comparably to a spinlock under little lock
-/// contention, and comparably to a platform lock under contention.
-public struct DispatchLock: Locking, MaybeLocking {
-    private let semaphore = DispatchSemaphore(value: 1)
+/// - On recent versions of Darwin (iOS 10.0, macOS 12.0, tvOS 1.0, watchOS 3.0,
+///   or better), this efficiency is a guarantee.
+/// - On Linux, BSD, or Android, waiters may spin briefly, and perform
+///   comparably to a kernel lock under contention.
+public struct NativeLock: Locking, MaybeLocking {
 
-    /// Creates a normal semaphore.
-    public init() {}
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    private enum Variant {
+        @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+        case os(ManagedBuffer<Void, os_unfair_lock>)
+        case dispatch(DispatchSemaphore)
 
-    private func withLock<Return>(before time: DispatchTime, body: () throws -> Return) rethrows -> Return? {
-        guard case .success = semaphore.wait(timeout: time) else { return nil }
-        defer {
-            semaphore.signal()
-        }
-        return try body()
-
-    }
-
-    public func withReadLock<Return>(_ body: () throws -> Return) rethrows -> Return {
-        return try withLock(before: .distantFuture, body: body)!
-    }
-
-    public func withAttemptedReadLock<Return>(_ body: () -> Return) -> Return? {
-        return withLock(before: .now(), body: body)
-    }
-}
-
-/// An unfair lock provided by the platform.
-///
-/// A spin lock conceptually polls to check the state of the lock, which is much
-/// faster when there isn't contention expected. No attempts at fairness or lock
-/// ordering are made.
-///
-/// In iOS 10.0, macOS 12.0, tvOS 1.0, watchOS 3.0, or better, the
-/// implementation does not actually spin on contention.
-///
-/// On prior versions of Darwin, or any platform that eagerly suspends threads
-/// for QoS, this may cause unexpected priority inversion, and should be used
-/// with care.
-public final class SpinLock: Locking, MaybeLocking {
-    private var lock = UnsafeSpinLock()
-
-    /// Creates a normal spinlock.
-    public init() {}
-
-    public func withReadLock<Return>(_ body: () throws -> Return) rethrows -> Return {
-        lock.lock()
-        defer {
-            lock.unlock()
-        }
-        return try body()
-    }
-
-    public func withAttemptedReadLock<Return>(_ body: () -> Return) -> Return? {
-        guard lock.tryLock() else { return nil }
-        defer {
-            lock.unlock()
-        }
-        return body()
-    }
-}
-
-/// A custom spin-lock with readers-writer semantics.
-///
-/// A spin lock will poll to check the state of the lock, which is much faster
-/// when there isn't contention expected. In addition, this lock attempts to
-/// allow many readers at the same time.
-///
-/// On Darwin, or any platform that eagerly suspends threads for QoS, this may
-/// cause unexpected priority inversion, and should be used with care.
-public final class CASSpinLock: Locking, MaybeLocking {
-    // Original inspiration: http://joeduffyblog.com/2009/01/29/a-singleword-readerwriter-spin-lock/
-    // Updated/optimized version: https://jfdube.wordpress.com/2014/01/12/optimizing-the-recursive-read-write-spinlock/
-    private enum Constants {
-        static var WriterMask: Int32 { return Int32(bitPattern: 0xFFF00000) }
-        static var ReaderMask: Int32 { return Int32(bitPattern: 0x000FFFFF) }
-        static var WriterOffset: Int32 { return Int32(bitPattern: 0x00100000) }
-    }
-
-    private var state = UnsafeAtomicInt32()
-
-    /// Creates a normal spinlock.
-    public init() {}
-
-    public func withWriteLock<Return>(_ body: () throws -> Return) rethrows -> Return {
-        // spin until we acquire write lock
-        repeat {
-            // wait for any active writer to release the lock
-            while (state.load(order: .relaxed) & Constants.WriterMask) != 0 {
-                UnsafeAtomicInt32.spin()
-            }
-
-            // increment the writer count
-            if (state.add(Constants.WriterOffset, order: .acquire) & Constants.WriterMask) == Constants.WriterOffset {
-                // wait until there are no more readers
-                while (state.load(order: .relaxed) & Constants.ReaderMask) != 0 {
-                    UnsafeAtomicInt32.spin()
+        init(value: Int) {
+            if #available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *) {
+                let buffer = ManagedBuffer<Void, os_unfair_lock>.create(minimumCapacity: 1, makingHeaderWith: { _ in })
+                buffer.withUnsafeMutablePointerToElements {
+                    $0.initialize(to: os_unfair_lock())
                 }
-
-                // write lock acquired
-                break
+                self = .os(buffer)
+            } else {
+                self = .dispatch(DispatchSemaphore(value: value))
             }
-
-            // there's another writer active; try again
-            state.subtract(Constants.WriterOffset, order: .release)
-        } while true
-
-        defer {
-            // decrement writers, potentially unblock readers
-            state.subtract(Constants.WriterOffset, order: .release)
         }
 
-        return try body()
+        func withReadLock<Return>(_ body: () throws -> Return) rethrows -> Return {
+            if #available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *), case let .os(buffer) = self {
+                return try buffer.withUnsafeMutablePointerToElements { (pointerToLock) -> Return in
+                    os_unfair_lock_lock(pointerToLock)
+                    defer { os_unfair_lock_unlock(pointerToLock) }
+                    return try body()
+                }
+            } else if case .dispatch(let semaphore) = self {
+                return try semaphore.withReadLock(body)
+            } else {
+                fatalError()
+            }
+        }
+
+        func withAttemptedReadLock<Return>(_ body: () -> Return) -> Return? {
+            if #available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *), case let .os(buffer) = self {
+                return buffer.withUnsafeMutablePointerToElements { (pointerToLock) -> Return? in
+                    guard os_unfair_lock_trylock(pointerToLock) else { return nil }
+                    defer { os_unfair_lock_unlock(pointerToLock) }
+                    return body()
+                }
+            } else if case .dispatch(let semaphore) = self {
+                return semaphore.withAttemptedReadLock(body)
+            } else {
+                fatalError()
+            }
+        }
+    }
+    #else
+    typealias Variant = DispatchSemaphore
+    #endif
+
+    private let storage: Variant
+
+    public init() {
+        storage = Variant(value: 1)
     }
 
     public func withReadLock<Return>(_ body: () throws -> Return) rethrows -> Return {
-        // spin until we acquire read lock
-        repeat {
-            // wait for active writer to release the lock
-            while (state.load(order: .relaxed) & Constants.WriterMask) != 0 {
-                UnsafeAtomicInt32.spin()
-            }
-
-            // increment the reader count
-            if (state.add(1, order: .acquire) & Constants.WriterMask) == 0 {
-                // read lock required
-                break
-            }
-
-            // a writer became active while locking; try again
-            state.subtract(1, order: .release)
-        } while true
-
-        defer {
-            // decrement readers, potentially unblock writers
-            state.subtract(1, order: .release)
-        }
-
-        return try body()
+        return try storage.withReadLock(body)
     }
 
     public func withAttemptedReadLock<Return>(_ body: () -> Return) -> Return? {
-        // active writer
-        guard (state.load(order: .relaxed) & Constants.WriterMask) == 0 else { return nil }
-
-        // increment the reader count
-        guard (state.add(1, order: .acquire) & Constants.WriterMask) == 0 else {
-            state.subtract(1, order: .release)
-            return nil
-        }
-
-        defer {
-            // decrement readers, potentially unblock writers
-            state.subtract(1, order: .release)
-        }
-
-        return body()
+        return storage.withAttemptedReadLock(body)
     }
+
 }
 
 /// A readers-writer lock provided by the platform implementation of the
 /// POSIX Threads standard. Read more: https://en.wikipedia.org/wiki/POSIX_Threads
-public final class PThreadReadWriteLock: Locking, MaybeLocking {
+public final class POSIXReadWriteLock: Locking, MaybeLocking {
     private var lock = pthread_rwlock_t()
 
     /// Create the standard platform lock.
@@ -253,5 +167,49 @@ public final class PThreadReadWriteLock: Locking, MaybeLocking {
             pthread_rwlock_unlock(&lock)
         }
         return try body()
+    }
+}
+
+/// A locking construct using a counting semaphore from Grand Central Dispatch.
+/// This locking type behaves the same for both read and write locks.
+///
+/// The semaphore lock performs comparably to a spinlock under little lock
+/// contention, and comparably to a platform lock under contention.
+extension DispatchSemaphore: Locking, MaybeLocking {
+    private func withLock<Return>(before time: DispatchTime, body: () throws -> Return) rethrows -> Return? {
+        guard case .success = wait(timeout: time) else { return nil }
+        defer {
+            signal()
+        }
+        return try body()
+
+    }
+
+    public func withReadLock<Return>(_ body: () throws -> Return) rethrows -> Return {
+        return try withLock(before: .distantFuture, body: body)!
+    }
+
+    public func withAttemptedReadLock<Return>(_ body: () -> Return) -> Return? {
+        return withLock(before: .now(), body: body)
+    }
+}
+
+/// A lock object from the Foundation Kit used to coordinate the operation of
+/// multiple threads of execution within the same application.
+extension NSLock: Locking, MaybeLocking {
+    public func withReadLock<Return>(_ body: () throws -> Return) rethrows -> Return {
+        lock()
+        defer {
+            unlock()
+        }
+        return try body()
+    }
+
+    public func withAttemptedReadLock<Return>(_ body: () -> Return) -> Return? {
+        guard `try`() else { return nil }
+        defer {
+            unlock()
+        }
+        return body()
     }
 }

--- a/Sources/Deferred/Protected.swift
+++ b/Sources/Deferred/Protected.swift
@@ -16,7 +16,7 @@ public final class Protected<T> {
     fileprivate var value: T
 
     /// Creates a protected `value` with a type implementing a `lock`.
-    public init(initialValue value: T, lock: Locking = CASSpinLock()) {
+    public init(initialValue value: T, lock: Locking = NativeLock()) {
         self.value = value
         self.lock = lock
     }

--- a/Sources/TestSupport/Fixtures.swift
+++ b/Sources/TestSupport/Fixtures.swift
@@ -14,12 +14,31 @@ import Task
 #endif
 
 import Dispatch
-import typealias Foundation.TimeInterval
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+import Darwin
+#else
+import Glibc
+#endif
 
 enum TestError: Error {
     case first
     case second
     case third
+}
+
+func sleep(_ duration: DispatchTimeInterval) {
+    var t = timespec(tv_sec: 0, tv_nsec: 0)
+    switch duration {
+    case .microseconds(let micro):
+        t.tv_nsec = micro * 1_000
+    case .nanoseconds(let nano):
+        t.tv_nsec = nano
+    case .milliseconds(let millo):
+        t.tv_nsec = millo * 1_000
+    case .seconds(let sec):
+        t.tv_sec = sec
+    }
+    nanosleep(&t, nil)
 }
 
 extension XCTestCase {
@@ -36,7 +55,7 @@ extension XCTestCase {
     }
 
     func waitForExpectations(file: StaticString = #file, line: UInt = #line) {
-        let timeout: TimeInterval = 10
+        let timeout: Double = 10
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             waitForExpectations(timeout: timeout, handler: nil)
         #else
@@ -45,7 +64,7 @@ extension XCTestCase {
     }
 
     func waitForExpectationsShort(file: StaticString = #file, line: UInt = #line) {
-        let timeout: TimeInterval = 3
+        let timeout: Double = 3
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             waitForExpectations(timeout: timeout, handler: nil)
         #else

--- a/Tests/DeferredTests/ProtectedTests.swift
+++ b/Tests/DeferredTests/ProtectedTests.swift
@@ -65,7 +65,7 @@ class ProtectedTests: XCTestCase {
                 for i in 0 ..< 5 {
                     dateItemsTuple.0 = Date()
                     dateItemsTuple.1.append(i)
-                    timeIntervalSleep(0.1)
+                    sleep(.milliseconds(100))
                 }
                 lastWriterDate = dateItemsTuple.0
             }


### PR DESCRIPTION
Brings list of types implementing the Locking protocol more in line with the ecosystem of Swift 3 and reducing the scope of our library.

#### What's in this pull request?

* Introduces `NativeLock`, the new default lock for `Protected`, backed by `os_unfair_lock` on Darwin 16 and by `DispatchSemaphore` on everything else.
* Makes `DispatchSemaphore` and `NSLock` conform to `Locking`.
* Renames `PThreadReadWriteLock` to `POSIXReadWriteLock`, in the spirit of the Swift community naming and the reality of pthread's implementation on some platforms. 
* Removes `CASSpinLock`, `SpinLock`, and the locking types' dependence on the `Atomics` module. ⚛


#### Testing

The number of lock types under test stays constant at 4. Performance tests still only available on Darwin due to some `NSThread` arcana.

The tests themselves have also shed their dependence on `Atomics` in favor of atomic math primitives [exposed by the stdlib](https://github.com/apple/swift/blob/master/stdlib/public/core/Runtime.swift.gyb#L130-L224). It is my assumption here that these won't become internal/private until Swift at least considers a threading solution.

#### API Changes

Breaking changes, summarized above. A user's migration path is to choose one of the new locking types.