### PR TITLE
Making TaskProgress more explicit for multithreaded overrelease (#137)

### DIFF
--- a/Sources/Deferred/Executor.swift
+++ b/Sources/Deferred/Executor.swift
@@ -59,7 +59,11 @@ public typealias DefaultExecutor = DispatchQueue
 extension Executor {
     /// By default, submits the closure contents of the work item.
     public func submit(_ workItem: DispatchWorkItem) {
-        submit(workItem.perform)
+        // This is ideally `submit(workItem.perform)`, but Swift 3.0.1 seems to
+        // have issues reabstracting it.
+        submit {
+            workItem.perform()
+        }
     }
 
     /// By default, `nil`; the executor's `submit(_:)` is used instead.

--- a/Sources/Deferred/Protected.swift
+++ b/Sources/Deferred/Protected.swift
@@ -62,6 +62,6 @@ extension Protected: CustomDebugStringConvertible, CustomReflectable, CustomPlay
     }
 
     public var customPlaygroundQuickLook: PlaygroundQuickLook {
-        return PlaygroundQuickLook(reflecting: (lock as? MaybeLocking).flatMap({ $0.withAttemptedReadLock { value } }))
+        return PlaygroundQuickLook(reflecting: (lock as? MaybeLocking).flatMap({ $0.withAttemptedReadLock { value } }) as Any)
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->

#### What's in this pull request?

Getting tests to run. Should be a fix for #137.

#### Testing
N/A
#### API Changes
N/A