### PR TITLE
Add a unit test that highlights the error when canceling a task produced using allSucceded

### DIFF
--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		DB55F20A1D96968E00FC1439 /* TaskWorkItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1FD1D96968E00FC1439 /* TaskWorkItemTests.swift */; };
 		DB55F20C1D969A1B00FC1439 /* FutureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F20B1D969A1B00FC1439 /* FutureTests.swift */; };
 		DBC742641DC2F6D4002FB30D /* FutureEveryMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC742631DC2F6D4002FB30D /* FutureEveryMap.swift */; };
+		EBEB828E1DC4A7FD00B7E089 /* TaskAllSucceededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBEB828C1DC4A79A00B7E089 /* TaskAllSucceededTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -115,6 +116,7 @@
 		DB55F1FD1D96968E00FC1439 /* TaskWorkItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskWorkItemTests.swift; sourceTree = "<group>"; };
 		DB55F20B1D969A1B00FC1439 /* FutureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureTests.swift; sourceTree = "<group>"; };
 		DBC742631DC2F6D4002FB30D /* FutureEveryMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureEveryMap.swift; sourceTree = "<group>"; };
+		EBEB828C1DC4A79A00B7E089 /* TaskAllSucceededTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskAllSucceededTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -278,6 +280,7 @@
 				DB55F1FB1D96968E00FC1439 /* TaskGroupTests.swift */,
 				DB55F1FC1D96968E00FC1439 /* TaskTests.swift */,
 				DB55F1FD1D96968E00FC1439 /* TaskWorkItemTests.swift */,
+				EBEB828C1DC4A79A00B7E089 /* TaskAllSucceededTests.swift */,
 			);
 			path = TaskTests;
 			sourceTree = "<group>";
@@ -431,6 +434,7 @@
 				DB55F20C1D969A1B00FC1439 /* FutureTests.swift in Sources */,
 				DB55F2041D96968E00FC1439 /* ProtectedTests.swift in Sources */,
 				DB55F2061D96968E00FC1439 /* TaskResultTests.swift in Sources */,
+				EBEB828E1DC4A7FD00B7E089 /* TaskAllSucceededTests.swift in Sources */,
 				DB55F1FE1D96968E00FC1439 /* Fixtures.swift in Sources */,
 				DB55F2051D96968E00FC1439 /* ResultRecoveryTests.swift in Sources */,
 				DB55F2091D96968E00FC1439 /* TaskTests.swift in Sources */,

--- a/Tests/TaskTests/TaskAllSucceededTests.swift
+++ b/Tests/TaskTests/TaskAllSucceededTests.swift
@@ -1,0 +1,140 @@
+//
+//  Created by Pierluigi Cifani on 29/10/2016.
+//  Copyright © 2016 Big Nerd Ranch. All rights reserved.
+//
+
+import XCTest
+import Dispatch
+
+#if SWIFT_PACKAGE
+    import Result
+    import Deferred
+    @testable import Task
+    @testable import TestSupport
+#else
+    @testable import Deferred
+#endif
+
+class TaskAllSucceededTests: XCTestCase {
+    static var allTests: [(String, (TaskAllSucceededTests) -> () throws -> Void)] {
+        return [
+            ("testThatCancellingATaskPropagatesTheCancellation", testThatCancellingATaskPropagatesTheCancellation),
+        ]
+    }
+    
+    func testThatCancellingATaskPropagatesTheCancellation() {
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var cancellationWasPropagated = false
+        
+        let task1 = TaskProducer.produceTask()
+        let task2 = TaskProducer.produceTask()
+        let task = [task1, task2].allSucceeded()
+        task.upon(DispatchQueue.any()) { result in
+            
+            defer { semaphore.signal() }
+            
+            guard let error = result.error, let taskError = error as? TaskProducerError else {
+                return
+            }
+
+            cancellationWasPropagated = (taskError == TaskProducerError.userCancelled)
+        }
+        _ = semaphore.wait(timeout: .now() + .seconds(5))
+        
+        XCTAssert(cancellationWasPropagated)
+    }
+}
+
+private enum TaskProducerError: Error {
+    case unknown
+    case userCancelled
+}
+
+private class TaskProducer {
+    
+    typealias SyncHandler = (NSError?) -> Void
+    
+    static func produceTask() -> Task<()> {
+        return syncFolder(folderID: "0")
+    }
+    
+    static private func sync(items: [Item]) -> [Task<()>] {
+        return items.map { (item) in
+            if item.isFolder {
+                return self.syncFolder(folder: item as! Folder)
+            } else {
+                return self.sync(file: item as! File)
+            }
+        }
+    }
+    
+    static private func syncFolder(folderID: String) -> Task<()> {
+        return fetchFolderInfo(folderID: folderID).andThen(upon: DispatchQueue.any()) { (items) in
+            return sync(items: items).allSucceeded()
+        }
+    }
+    
+    static private func syncFolder(folder: Folder) -> Task<()> {
+        return syncFolder(folderID: folder.modelID)
+    }
+    
+    static private func sync(file: File) -> Task<()> {
+        let deferred = Deferred<TaskResult<()>>()
+        
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.3) {
+            deferred.fill(with: .success())
+        }
+        
+        return Task(future: Future(deferred), cancellation: {
+            deferred.fill(with: .failure(TaskProducerError.userCancelled))
+        })
+    }
+    
+    static private func fetchFolderInfo(folderID: String) -> Task<[Item]> {
+        let deferred = Deferred<TaskResult<[Item]>>()
+        
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+            let items = [File(), File(), File(), File(), File()]
+            deferred.fill(with: .success((items)))
+        }
+        
+        return Task(future: Future(deferred), cancellation: {
+            deferred.fill(with: .failure(TaskProducerError.userCancelled))
+        })
+    }
+}
+
+//MARK: Model
+
+private protocol Item {
+    var modelID: String { get }
+    var isFolder: Bool { get }
+    var isFile: Bool { get }
+}
+
+private struct File: Item {
+    var modelID: String = String.random()
+    let isFolder: Bool = false
+    let isFile: Bool = true
+}
+
+private struct Folder: Item {
+    var modelID: String = String.random()
+    let isFolder: Bool = true
+    let isFile: Bool = false
+}
+
+extension String {
+    
+    static func random(length: Int = 20) -> String {
+        let base = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        var randomString: String = ""
+        
+        for _ in 0..<length {
+            let randomValue = arc4random_uniform(UInt32(base.characters.count))
+            randomString += "\(base[base.index(base.startIndex, offsetBy: Int(randomValue))])"
+        }
+        return randomString
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->

#### What's in this pull request?
<!-- Write an introduction, and state the goal of the pull request. -->
I have found that sometimes a `cancel` message is not propagated correctly thorough the `NSProgress` hierarchy when created with `allSucceeded`. 

#### Testing
<!-- Changes to test coverage, and whether or not the resulting tests pass on your machine. -->
A test has been added that highlights this error.

#### API Changes
<!-- If this pull request causes any API changes (breaking or non-breaking), not them here. -->
None