### PR TITLE
Work around broken id-as-Any casts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: generic
 os: osx
-osx_image: xcode8
+osx_image: xcode8.1
 before_install:
 - rvm use $(< .ruby-version) --install --binary --fuzzy
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ after_success:
   fi
 after_failure:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    cat ~/Library/Logs/DiagnosticReports/xctest_*.crash;
     cat ~/Library/Developer/Xcode/DerivedData/Deferred-*/Logs/Test/*/Session-DeferredTests-*.log;
   fi
 notifications:

--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DB40026B1DDC225200382BAE /* SwiftBugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB4002691DDC21B300382BAE /* SwiftBugTests.swift */; };
 		DB524C7B1D851E3800DDF16D /* Deferred.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB524C711D851E3800DDF16D /* Deferred.framework */; };
 		DB524CC21D85202C00DDF16D /* Deferred.h in Headers */ = {isa = PBXBuildFile; fileRef = DB524CA11D85200C00DDF16D /* Deferred.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB524CD11D85204B00DDF16D /* Deferred.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524C931D85200C00DDF16D /* Deferred.swift */; };
@@ -64,6 +65,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		DB4002691DDC21B300382BAE /* SwiftBugTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftBugTests.swift; sourceTree = "<group>"; };
 		DB524C711D851E3800DDF16D /* Deferred.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Deferred.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB524C7A1D851E3800DDF16D /* DeferredTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DeferredTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB524C8C1D851E5B00DDF16D /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
@@ -260,6 +262,7 @@
 				DB55F20B1D969A1B00FC1439 /* FutureTests.swift */,
 				DB55F1F41D96968E00FC1439 /* LockingTests.swift */,
 				DB55F1F51D96968E00FC1439 /* ProtectedTests.swift */,
+				DB4002691DDC21B300382BAE /* SwiftBugTests.swift */,
 			);
 			path = DeferredTests;
 			sourceTree = "<group>";
@@ -443,6 +446,7 @@
 				DB55F2081D96968E00FC1439 /* TaskGroupTests.swift in Sources */,
 				DB55F2011D96968E00FC1439 /* FutureCustomExecutorTests.swift in Sources */,
 				DB55F2001D96968E00FC1439 /* ExistentialFutureTests.swift in Sources */,
+				DB40026B1DDC225200382BAE /* SwiftBugTests.swift in Sources */,
 				DB55F2021D96968E00FC1439 /* FutureIgnoreTests.swift in Sources */,
 				DB55F20A1D96968E00FC1439 /* TaskWorkItemTests.swift in Sources */,
 				DB55F2031D96968E00FC1439 /* LockingTests.swift in Sources */,

--- a/Sources/Deferred/Deferred.swift
+++ b/Sources/Deferred/Deferred.swift
@@ -105,7 +105,7 @@ public final class Deferred<Value>: FutureProtocol, PromiseProtocol {
     }
 }
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if swift(>=3.1) && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
 private typealias DeferredRaw<T> = Unmanaged<AnyObject>
 #else
 // In order to assign the value of a scalar in a Deferred using atomics, we must
@@ -145,7 +145,7 @@ private final class DeferredStorage<Value>: ManagedBuffer<Void, DeferredRaw<Valu
 
     static func unbox(from ptr: UnsafeMutableRawPointer) -> Value {
         let raw = Element.fromOpaque(ptr)
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if swift(>=3.1) && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
         return raw.takeUnretainedValue() as! Value
         #else
         return raw.takeUnretainedValue().contents
@@ -153,7 +153,7 @@ private final class DeferredStorage<Value>: ManagedBuffer<Void, DeferredRaw<Valu
     }
 
     static func box(_ value: Value) -> Element {
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if swift(>=3.1) && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
         return Unmanaged.passRetained(value as AnyObject)
         #else
         return Unmanaged.passRetained(Box(value))

--- a/Sources/Deferred/Deferred.swift
+++ b/Sources/Deferred/Deferred.swift
@@ -143,10 +143,10 @@ private final class DeferredStorage<Value>: ManagedBuffer<Void, DeferredRaw<Valu
         Element.fromOpaque(ptr).release()
     }
 
-    static func unbox(from ptr: UnsafeMutableRawPointer) -> Value! {
+    static func unbox(from ptr: UnsafeMutableRawPointer) -> Value {
         let raw = Element.fromOpaque(ptr)
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-        return raw.takeUnretainedValue() as? Value
+        return raw.takeUnretainedValue() as! Value
         #else
         return raw.takeUnretainedValue().contents
         #endif

--- a/Sources/TestSupport/Fixtures.swift
+++ b/Sources/TestSupport/Fixtures.swift
@@ -136,3 +136,33 @@ extension RandomAccessCollection {
     }
 
 }
+
+enum SomeMultipayloadEnum: Hashable {
+    case one
+    case two(String)
+    case three(Double)
+
+    var hashValue: Int {
+        switch self {
+        case .one:
+            return 1
+        case .two(let str):
+            return str.hashValue
+        case .three(let obj):
+            return obj.hashValue
+        }
+    }
+
+    static func ==(lhs: SomeMultipayloadEnum, rhs: SomeMultipayloadEnum) -> Bool {
+        switch (lhs, rhs) {
+        case (.one, .one):
+            return true
+        case let (.two(lhs), .two(rhs)):
+            return lhs == rhs
+        case let (.three(lhs), .three(rhs)):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}

--- a/Tests/DeferredTests/DeferredTests.swift
+++ b/Tests/DeferredTests/DeferredTests.swift
@@ -41,7 +41,8 @@ class DeferredTests: XCTestCase {
             ("testDeferredOptionalBehavesCorrectly", testDeferredOptionalBehavesCorrectly),
             ("testIsFilledCanBeCalledMultipleTimesNotFilled", testIsFilledCanBeCalledMultipleTimesNotFilled),
             ("testIsFilledCanBeCalledMultipleTimesWhenFilled", testIsFilledCanBeCalledMultipleTimesWhenFilled),
-            ("testFillAndIsFilledPostcondition", testFillAndIsFilledPostcondition)
+            ("testFillAndIsFilledPostcondition", testFillAndIsFilledPostcondition),
+            ("testSimultaneousFill", testSimultaneousFill)
         ]
 
         #if os(OSX)

--- a/Tests/DeferredTests/SwiftBugTests.swift
+++ b/Tests/DeferredTests/SwiftBugTests.swift
@@ -1,0 +1,64 @@
+//
+//  SwiftBugTests.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 11/16/16.
+//  Copyright © 2016 Big Nerd Ranch. All rights reserved.
+//
+
+import XCTest
+@testable import Deferred
+#if SWIFT_PACKAGE
+@testable import TestSupport
+#endif
+
+import Dispatch
+
+class SwiftBugTests: XCTestCase {
+    static var allTests: [(String, (SwiftBugTests) -> () throws -> Void)] {
+        return [
+            ("testIdAsAnyDictionaryDowncast", testIdAsAnyDictionaryDowncast),
+            ("testIdAsAnyArrayDowncast", testIdAsAnyArrayDowncast)
+        ]
+    }
+
+    // #150: In Swift 3.0 ..< 3.0.1, Swift collections have some trouble round-
+    // tripping through id-as-Any using `as?`. (SR-????)
+    func testIdAsAnyDictionaryDowncast() {
+        let deferred = Deferred<[SomeMultipayloadEnum: SomeMultipayloadEnum]>()
+
+        let keys: [SomeMultipayloadEnum] = [ .one, .two("foo"), .three(42) ]
+
+        let toBeFilledWith: [SomeMultipayloadEnum: SomeMultipayloadEnum] = [
+            keys[0]: .two("one"),
+            keys[1]: .two("two"),
+            keys[2]: .two("three"),
+        ]
+
+        let expect = expectation(description: "upon is called with correct values")
+        deferred.upon { (dict) in
+            XCTAssertEqual(dict, toBeFilledWith)
+            expect.fulfill()
+        }
+
+        deferred.fill(with: toBeFilledWith)
+        waitForExpectationsShort()
+    }
+
+    // Variant of #150: In Swift 3.0 ..< 3.0.1, Swift collections have some
+    // trouble round- tripping through id-as-Any using `as!`. (SR-2490)
+    func testIdAsAnyArrayDowncast() {
+        let deferred = Deferred<[SomeMultipayloadEnum]>()
+
+        let toBeFilledWith: [SomeMultipayloadEnum] = [ .one, .two("foo"), .three(42) ]
+
+        let expect = expectation(description: "upon is called with correct values")
+        deferred.upon { (array) in
+            XCTAssertEqual(array.count, toBeFilledWith.count)
+            expect.fulfill()
+        }
+
+        deferred.fill(with: toBeFilledWith)
+        waitForExpectationsShort()
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -13,6 +13,7 @@ import XCTest
 
 XCTMain([
     testCase(DeferredTests.allTests),
+    testCase(SwiftBugTests.allTests),
     testCase(ExistentialFutureTests.allTests),
     testCase(FutureCustomExecutorTests.allTests),
     testCase(FutureIgnoreTests.allTests),


### PR DESCRIPTION
#### What's in this pull request?

Fixes for #150.

The Swift bug in #150 is fixed in Swift 3.0.2, and the bug from my attempted fix (to use `as!`, which was always more correct) was fixed in Swift 3.0.1. As `#if swift` doesn't support `x.y.z`, we push out use of this optimization until Swift 3.1. Sad panda.

#### Testing

Thanks to @preble for the reduced test cases.

#### API Changes

N/A