### PR TITLE
Extend PreferredExecutor benefits to map and andThen

### DIFF
--- a/Sources/Deferred/Future.swift
+++ b/Sources/Deferred/Future.swift
@@ -51,6 +51,47 @@ public protocol FutureProtocol: CustomDebugStringConvertible, CustomReflectable,
     /// - parameter time: A deadline for the value to be determined.
     /// - returns: The determined value, if filled within the timeout, or `nil`.
     func wait(until time: DispatchTime) -> Value?
+
+    /// Returns a future containing the result of mapping `transform` over the
+    /// deferred value.
+    func map<NewValue>(upon executor: PreferredExecutor, transform: @escaping(Value) -> NewValue) -> Future<NewValue>
+
+    /// Returns a future containing the result of mapping `transform` over the
+    /// deferred value.
+    ///
+    /// `map` submits the `transform` to the `executor` once the future's value
+    /// is determined.
+    ///
+    /// - parameter executor: Context to execute the transformation on.
+    /// - parameter transform: Creates something using the deferred value.
+    /// - returns: A new future that is filled once the receiver is determined.
+    func map<NewValue>(upon executor: Executor, transform: @escaping(Value) -> NewValue) -> Future<NewValue>
+
+    /// Begins another asynchronous operation by passing the deferred value to
+    /// `requestNextValue` once it becomes determined.
+    ///
+    /// `andThen` is similar to `map`, but `requestNextValue` returns another
+    /// future instead of an immediate value. Use `andThen` when you want
+    /// the reciever to feed into another asynchronous operation. You might hear
+    /// this referred to as "chaining" or "binding".
+    func andThen<NewFuture: FutureProtocol>(upon executor: PreferredExecutor, start requestNextValue: @escaping(Value) -> NewFuture) -> Future<NewFuture.Value>
+
+    /// Begins another asynchronous operation by passing the deferred value to
+    /// `requestNextValue` once it becomes determined.
+    ///
+    /// `andThen` is similar to `map`, but `requestNextValue` returns another
+    /// future instead of an immediate value. Use `andThen` when you want
+    /// the reciever to feed into another asynchronous operation. You might hear
+    /// this referred to as "chaining" or "binding".
+    ///
+    /// - note: It is important to keep in mind the thread safety of the
+    /// `requestNextValue` closure. Creating a new asynchronous task typically
+    /// involves state. Ensure the function is compatible with `executor`.
+    ///
+    /// - parameter executor: Context to execute the transformation on.
+    /// - parameter requestNextValue: Start a new operation with the future value.
+    /// - returns: The new deferred value returned by the `transform`.
+    func andThen<NewFuture: FutureProtocol>(upon executor: Executor, start requestNextValue: @escaping(Value) -> NewFuture) -> Future<NewFuture.Value>
 }
 
 extension FutureProtocol {

--- a/Sources/Deferred/FutureAndThen.swift
+++ b/Sources/Deferred/FutureAndThen.swift
@@ -7,21 +7,10 @@
 //
 
 extension FutureProtocol {
-    /// Begins another asynchronous operation by passing the deferred value to
-    /// `requestNextValue` once it becomes determined.
-    ///
-    /// `andThen` is similar to `map`, but `requestNextValue` returns another
-    /// future instead of an immediate value. Use `andThen` when you want
-    /// the reciever to feed into another asynchronous operation. You might hear
-    /// this referred to as "chaining" or "binding".
-    ///
-    /// - note: It is important to keep in mind the thread safety of the
-    /// `requestNextValue` closure. Creating a new asynchronous task typically
-    /// involves state. Ensure the function is compatible with `executor`.
-    ///
-    /// - parameter executor: Context to execute the transformation on.
-    /// - parameter requestNextValue: Start a new operation with the future value.
-    /// - returns: The new deferred value returned by the `transform`.
+    public func andThen<NewFuture: FutureProtocol>(upon executor: PreferredExecutor, start requestNextValue: @escaping(Value) -> NewFuture) -> Future<NewFuture.Value> {
+        return andThen(upon: executor as Executor, start: requestNextValue)
+    }
+
     public func andThen<NewFuture: FutureProtocol>(upon executor: Executor, start requestNextValue: @escaping(Value) -> NewFuture) -> Future<NewFuture.Value> {
         let d = Deferred<NewFuture.Value>()
         upon(executor) {

--- a/Sources/Deferred/FutureEveryMap.swift
+++ b/Sources/Deferred/FutureEveryMap.swift
@@ -19,12 +19,6 @@ private struct LazyMapFuture<Base: FutureProtocol, NewValue>: FutureProtocol {
         self.transform = transform
     }
 
-    func upon(_ executor: Base.PreferredExecutor, execute body: @escaping(NewValue) -> Void) {
-        return base.upon(executor) { [transform] in
-            body(transform($0))
-        }
-    }
-
     func upon(_ executor: Executor, execute body: @escaping(NewValue) -> Void) {
         return base.upon(executor) { [transform] in
             body(transform($0))

--- a/Sources/Deferred/FutureMap.swift
+++ b/Sources/Deferred/FutureMap.swift
@@ -7,15 +7,10 @@
 //
 
 extension FutureProtocol {
-    /// Returns a future containing the result of mapping `transform` over the
-    /// deferred value.
-    ///
-    /// `map` submits the `transform` to the `executor` once the future's value
-    /// is determined.
-    ///
-    /// - parameter executor: Context to execute the transformation on.
-    /// - parameter transform: Creates something using the deferred value.
-    /// - returns: A new future that is filled once the receiver is determined.
+    public func map<NewValue>(upon executor: PreferredExecutor, transform: @escaping(Value) -> NewValue) -> Future<NewValue> {
+        return map(upon: executor as Executor, transform: transform)
+    }
+
     public func map<NewValue>(upon executor: Executor, transform: @escaping(Value) -> NewValue) -> Future<NewValue> {
         let d = Deferred<NewValue>()
         upon(executor) {

--- a/Sources/Task/ExistentialTask.swift
+++ b/Sources/Task/ExistentialTask.swift
@@ -102,7 +102,6 @@ public final class Task<SuccessValue>: NSObject {
 
 extension Task: FutureProtocol {
     public typealias Value = Result
-    public typealias PreferredExecutor = Future<Result>.PreferredExecutor
 
     public func upon(_ queue: PreferredExecutor, execute body: @escaping(Result) -> ()) {
         future.upon(queue, execute: body)

--- a/Sources/Task/ResultFuture.swift
+++ b/Sources/Task/ResultFuture.swift
@@ -49,7 +49,7 @@ extension FutureProtocol where Value: Either {
     ///
     /// - see: uponSuccess(on:execute:)
     /// - see: upon(_:execute:)
-    public func uponSuccess(on executor: PreferredExecutor, execute body: @escaping(Value.Right) -> Void) {
+    public func uponSuccess(on executor: PreferredExecutor = .any(), execute body: @escaping(Value.Right) -> Void) {
         upon(executor, execute: commonSuccessBody(body))
     }
 
@@ -57,25 +57,8 @@ extension FutureProtocol where Value: Either {
     ///
     /// - see: uponFailure(on:execute:)
     /// - see: upon(_:body:)
-    public func uponFailure(on executor: PreferredExecutor, execute body: @escaping(Value.Left) -> Void) {
+    public func uponFailure(on executor: PreferredExecutor = .any(), execute body: @escaping(Value.Left) -> Void) {
         upon(executor, execute: commonFailureBody(body))
-    }
-}
-
-extension FutureProtocol where Value: Either, PreferredExecutor == DispatchQueue {
-    /// Call some `body` in the background if the future successfully resolves
-    /// a value.
-    ///
-    /// - see: uponSuccess(on:execute:)
-    public func uponSuccess(execute body: @escaping(Value.Right) -> Void) {
-        upon(.any(), execute: commonSuccessBody(body))
-    }
-
-    /// Call some `body` in the background if the future produces an error.
-    ///
-    /// - see: uponFailure(on:execute:)
-    public func uponFailure(execute body: @escaping(Value.Left) -> Void) {
-        upon(.any(), execute: commonFailureBody(body))
     }
 }
 

--- a/Sources/Task/TaskAndThen.swift
+++ b/Sources/Task/TaskAndThen.swift
@@ -22,6 +22,19 @@ extension Task {
     ///
     /// Cancelling the resulting task will attempt to cancel both the recieving
     /// task and the created task.
+    public func andThen<NewTask: FutureProtocol>(upon executor: PreferredExecutor, start startNextTask: @escaping(SuccessValue) throws -> NewTask) -> Task<NewTask.Value.Right>
+        where NewTask.Value: Either, NewTask.Value.Left == Error {
+        return andThen(upon: executor as Executor, start: startNextTask)
+    }
+
+    /// Begins another task by passing the result of the task to `startNextTask`
+    /// once it completes successfully.
+    ///
+    /// Chaining a task appends a unit of progress to the root task. A root task
+    /// is the earliest, or parent-most, task in a tree of tasks.
+    ///
+    /// Cancelling the resulting task will attempt to cancel both the recieving
+    /// task and the created task.
     ///
     /// - note: It is important to keep in mind the thread safety of the
     /// `startNextTask` closure. `andThen` submits `startNextTask` to `executor`

--- a/Sources/Task/TaskMap.swift
+++ b/Sources/Task/TaskMap.swift
@@ -15,6 +15,17 @@ extension Task {
     /// Returns a `Task` containing the result of mapping `transform` over the
     /// successful task's value.
     ///
+    /// Mapping a task appends a unit of progress to the root task. A root task
+    /// is the earliest, or parent-most, task in a tree of tasks.
+    ///
+    /// The resulting task is cancellable in the same way the recieving task is.
+    public func map<NewSuccessValue>(upon queue: PreferredExecutor, transform: @escaping(SuccessValue) throws -> NewSuccessValue) -> Task<NewSuccessValue> {
+        return map(upon: queue as Executor, transform: transform)
+    }
+
+    /// Returns a `Task` containing the result of mapping `transform` over the
+    /// successful task's value.
+    ///
     /// The `transform` is submitted to the `executor` once the task completes.
     ///
     /// Mapping a task appends a unit of progress to the root task. A root task


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->

#### What's in this pull request?

In practice, having to use `andThen(upon: DispatchQueue.any()) { … }` sucks, it should at least be `andThen(upon: .any()) { … }` 

#### Testing

At some later point, we should come back and copy-paste our tests to work with the wrapper versions.

#### API Changes

Removes `associatedtype PreferredExecutor`, among others.