### PR TITLE
Add a new Recover that takes a function that produces a new task

### DIFF
--- a/Tests/TaskTests/TaskTests.swift
+++ b/Tests/TaskTests/TaskTests.swift
@@ -266,5 +266,21 @@ class TaskTests: CustomExecutorTestCase {
         waitForExpectations()
         assertExecutorCalled(atLeast: 1)
     }
+    
+    func testThatRecoverAlsoProducesANewTask() {
+        let expectation = self.expectation(description: "recover produces a new task")
+        let task: Task<Int> = anyFailedTask.recoverWithNewTask(upon: executor) { _ in
+            return self.anyFinishedTask
+        }
+        
+        task.upon {
+            XCTAssertEqual($0.value, 42)
+            expectation.fulfill()
+        }
+        
+        waitForExpectations()
+        assertExecutorCalled(2)
+    }
+
     #endif
 }


### PR DESCRIPTION
#### What's in this pull request?
Like mentioned in https://github.com/bignerdranch/Deferred/issues/149, right now, there is a way to recover from an error and produce a new default value for the `SuccessValue`. I think a way to recover from an error by producing a new `Task` for the same `SuccessValue` would be helpful.

I wrote a naive implementation for this requirement but I could not get correctly some features like cancellation and `NSProgress` wrapping.

#### Testing
A unit test for this new method is added to the suite

#### API Changes
A new `recover` method is available