### PR TITLE
Adds a variant of recover for producing a new task

### DIFF
--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		DB524CE91D85205400DDF16D /* TaskAndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CAF1D85200C00DDF16D /* TaskAndThen.swift */; };
 		DB524CEA1D85205400DDF16D /* TaskMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CB01D85200C00DDF16D /* TaskMap.swift */; };
 		DB524CEB1D85205400DDF16D /* TaskProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CB11D85200C00DDF16D /* TaskProgress.swift */; };
-		DB524CEC1D85205400DDF16D /* TaskRecover.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CB21D85200C00DDF16D /* TaskRecover.swift */; };
+		DB524CEC1D85205400DDF16D /* TaskRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB524CB21D85200C00DDF16D /* TaskRecovery.swift */; };
 		DB55F1FE1D96968E00FC1439 /* Fixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1EE1D96968E00FC1439 /* Fixtures.swift */; };
 		DB55F1FF1D96968E00FC1439 /* DeferredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1F01D96968E00FC1439 /* DeferredTests.swift */; };
 		DB55F2001D96968E00FC1439 /* ExistentialFutureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55F1F11D96968E00FC1439 /* ExistentialFutureTests.swift */; };
@@ -98,7 +98,7 @@
 		DB524CAF1D85200C00DDF16D /* TaskAndThen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskAndThen.swift; sourceTree = "<group>"; };
 		DB524CB01D85200C00DDF16D /* TaskMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskMap.swift; sourceTree = "<group>"; };
 		DB524CB11D85200C00DDF16D /* TaskProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskProgress.swift; sourceTree = "<group>"; };
-		DB524CB21D85200C00DDF16D /* TaskRecover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRecover.swift; sourceTree = "<group>"; };
+		DB524CB21D85200C00DDF16D /* TaskRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRecovery.swift; sourceTree = "<group>"; };
 		DB524CBA1D85200C00DDF16D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DB524CFD1D85489500DDF16D /* Atomics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Atomics.h; path = include/Atomics.h; sourceTree = "<group>"; };
 		DB55F1EE1D96968E00FC1439 /* Fixtures.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Fixtures.swift; path = Sources/TestSupport/Fixtures.swift; sourceTree = SOURCE_ROOT; };
@@ -223,7 +223,7 @@
 				DB524CAA1D85200C00DDF16D /* TaskIgnore.swift */,
 				DB524CB01D85200C00DDF16D /* TaskMap.swift */,
 				DB524CB11D85200C00DDF16D /* TaskProgress.swift */,
-				DB524CB21D85200C00DDF16D /* TaskRecover.swift */,
+				DB524CB21D85200C00DDF16D /* TaskRecovery.swift */,
 				DB524CA81D85200C00DDF16D /* TaskWorkItem.swift */,
 			);
 			path = Task;
@@ -417,7 +417,7 @@
 				DB524CE71D85205400DDF16D /* TaskGroup.swift in Sources */,
 				DB524CE01D85205200DDF16D /* Either.swift in Sources */,
 				DB524CE81D85205400DDF16D /* TaskCollections.swift in Sources */,
-				DB524CEC1D85205400DDF16D /* TaskRecover.swift in Sources */,
+				DB524CEC1D85205400DDF16D /* TaskRecovery.swift in Sources */,
 				DB524CD51D85204B00DDF16D /* FutureComposition.swift in Sources */,
 				DB524CE61D85205400DDF16D /* ResultPromise.swift in Sources */,
 				DB524CE21D85205400DDF16D /* TaskWorkItem.swift in Sources */,

--- a/Sources/Task/TaskAndThen.swift
+++ b/Sources/Task/TaskAndThen.swift
@@ -20,7 +20,7 @@ extension Task {
     /// Chaining a task appends a unit of progress to the root task. A root task
     /// is the earliest, or parent-most, task in a tree of tasks.
     ///
-    /// Cancelling the resulting task will attempt to cancel both the recieving
+    /// Cancelling the resulting task will attempt to cancel both the receiving
     /// task and the created task.
     public func andThen<NewTask: FutureProtocol>(upon executor: PreferredExecutor, start startNextTask: @escaping(SuccessValue) throws -> NewTask) -> Task<NewTask.Value.Right>
         where NewTask.Value: Either, NewTask.Value.Left == Error {
@@ -33,7 +33,7 @@ extension Task {
     /// Chaining a task appends a unit of progress to the root task. A root task
     /// is the earliest, or parent-most, task in a tree of tasks.
     ///
-    /// Cancelling the resulting task will attempt to cancel both the recieving
+    /// Cancelling the resulting task will attempt to cancel both the receiving
     /// task and the created task.
     ///
     /// - note: It is important to keep in mind the thread safety of the

--- a/Sources/Task/TaskIgnore.swift
+++ b/Sources/Task/TaskIgnore.swift
@@ -20,7 +20,7 @@ extension Task {
     ///
     /// But behaves more efficiently.
     ///
-    /// The resulting task is cancellable in the same way the recieving task is.
+    /// The resulting task is cancellable in the same way the receiving task is.
     ///
     /// - see: map(transform:)
     public func ignored() -> Task<Void> {

--- a/Sources/Task/TaskMap.swift
+++ b/Sources/Task/TaskMap.swift
@@ -18,7 +18,7 @@ extension Task {
     /// Mapping a task appends a unit of progress to the root task. A root task
     /// is the earliest, or parent-most, task in a tree of tasks.
     ///
-    /// The resulting task is cancellable in the same way the recieving task is.
+    /// The resulting task is cancellable in the same way the receiving task is.
     public func map<NewSuccessValue>(upon queue: PreferredExecutor, transform: @escaping(SuccessValue) throws -> NewSuccessValue) -> Task<NewSuccessValue> {
         return map(upon: queue as Executor, transform: transform)
     }
@@ -31,7 +31,7 @@ extension Task {
     /// Mapping a task appends a unit of progress to the root task. A root task
     /// is the earliest, or parent-most, task in a tree of tasks.
     ///
-    /// The resulting task is cancellable in the same way the recieving task is.
+    /// The resulting task is cancellable in the same way the receiving task is.
     ///
     /// - see: FutureProtocol.map(upon:transform:)
     public func map<NewSuccessValue>(upon executor: Executor, transform: @escaping(SuccessValue) throws -> NewSuccessValue) -> Task<NewSuccessValue> {

--- a/Sources/Task/TaskRecover.swift
+++ b/Sources/Task/TaskRecover.swift
@@ -16,6 +16,17 @@ extension Task {
     /// Returns a `Task` containing the result of mapping `substitution` over
     /// the failed task's error.
     ///
+    /// Recovering from a failed task appends a unit of progress to the root
+    /// task. A root task is the earliest, or parent-most, task in a tree.
+    ///
+    /// The resulting task is cancellable in the same way the recieving task is.
+    public func recover(upon executor: PreferredExecutor, substituting substitution: @escaping(Error) throws -> SuccessValue) -> Task<SuccessValue> {
+        return recover(upon: executor as Executor, substituting: substitution)
+    }
+    
+    /// Returns a `Task` containing the result of mapping `substitution` over
+    /// the failed task's error.
+    ///
     /// `recover` submits the `substitution` to the `executor` once the task
     /// fails.
     ///

--- a/Sources/Task/TaskRecover.swift
+++ b/Sources/Task/TaskRecover.swift
@@ -32,7 +32,7 @@ extension Task {
 
         let future: Future<TaskResult<SuccessValue>> = map(upon: executor) { (result) in
             #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-            self.progress.becomeCurrent(withPendingUnitCount: 1)
+            progress.becomeCurrent(withPendingUnitCount: 1)
             defer { progress.resignCurrent() }
             #endif
 

--- a/Sources/Task/TaskRecovery.swift
+++ b/Sources/Task/TaskRecovery.swift
@@ -19,7 +19,7 @@ extension Task {
     /// Recovering from a failed task appends a unit of progress to the root
     /// task. A root task is the earliest, or parent-most, task in a tree.
     ///
-    /// The resulting task is cancellable in the same way the recieving task is.
+    /// The resulting task is cancellable in the same way the receiving task is.
     public func recover(upon executor: PreferredExecutor, substituting substitution: @escaping(Error) throws -> SuccessValue) -> Task<SuccessValue> {
         return recover(upon: executor as Executor, substituting: substitution)
     }
@@ -33,7 +33,7 @@ extension Task {
     /// Recovering from a failed task appends a unit of progress to the root
     /// task. A root task is the earliest, or parent-most, task in a tree.
     ///
-    /// The resulting task is cancellable in the same way the recieving task is.
+    /// The resulting task is cancellable in the same way the receiving task is.
     ///
     /// - see: FutureProtocol.map(upon:transform:)
     public func recover(upon executor: Executor, substituting substitution: @escaping(Error) throws -> SuccessValue) -> Task<SuccessValue> {
@@ -65,7 +65,7 @@ extension Task {
     /// Chaining a task appends a unit of progress to the root task. A root task
     /// is the earliest, or parent-most, task in a tree of tasks.
     ///
-    /// Cancelling the resulting task will attempt to cancel both the recieving
+    /// Cancelling the resulting task will attempt to cancel both the receiving
     /// task and the created task.
     public func fallback<NewTask: FutureProtocol>(upon executor: PreferredExecutor, to restartTask: @escaping(Error) -> NewTask) -> Task<SuccessValue> where NewTask.Value: Either, NewTask.Value.Left == Error, NewTask.Value.Right == SuccessValue {
         return fallback(upon: executor as Executor, to: restartTask)
@@ -77,7 +77,7 @@ extension Task {
     /// Chaining a task appends a unit of progress to the root task. A root task
     /// is the earliest, or parent-most, task in a tree of tasks.
     ///
-    /// Cancelling the resulting task will attempt to cancel both the recieving
+    /// Cancelling the resulting task will attempt to cancel both the receiving
     /// task and the created task.
     ///
     /// - note: It is important to keep in mind the thread safety of the

--- a/Sources/Task/TaskRecovery.swift
+++ b/Sources/Task/TaskRecovery.swift
@@ -1,5 +1,5 @@
 //
-//  TaskRecover.swift
+//  TaskRecovery.swift
 //  Deferred
 //
 //  Created by Zachary Waldowski on 10/27/15.
@@ -58,18 +58,55 @@ extension Task {
         return Task<SuccessValue>(future: future, cancellation: cancel)
         #endif
     }
-
-    public func recoverWithNewTask(upon executor: Executor, start startNextTask: @escaping(Error) -> Task<SuccessValue>) -> Task<SuccessValue> {
+    
+    /// Begins another task in the case of the failure of `self` by calling
+    /// `restartTask` with the error.
+    ///
+    /// Chaining a task appends a unit of progress to the root task. A root task
+    /// is the earliest, or parent-most, task in a tree of tasks.
+    ///
+    /// Cancelling the resulting task will attempt to cancel both the recieving
+    /// task and the created task.
+    public func fallback<NewTask: FutureProtocol>(upon executor: PreferredExecutor, to restartTask: @escaping(Error) -> NewTask) -> Task<SuccessValue> where NewTask.Value: Either, NewTask.Value.Left == Error, NewTask.Value.Right == SuccessValue {
+        return fallback(upon: executor as Executor, to: restartTask)
+    }
+    
+    /// Begins another task in the case of the failure of `self` by calling
+    /// `restartTask` with the error.
+    ///
+    /// Chaining a task appends a unit of progress to the root task. A root task
+    /// is the earliest, or parent-most, task in a tree of tasks.
+    ///
+    /// Cancelling the resulting task will attempt to cancel both the recieving
+    /// task and the created task.
+    ///
+    /// - note: It is important to keep in mind the thread safety of the
+    /// `restartTask` closure. `fallback` submits `restartTask` to `executor`
+    /// once the task fails.
+    /// - see: FutureProtocol.andThen(upon:start:)
+    public func fallback<NewTask: FutureProtocol>(upon executor: Executor, to restartTask: @escaping(Error) -> NewTask) -> Task<SuccessValue> where NewTask.Value: Either, NewTask.Value.Left == Error, NewTask.Value.Right == SuccessValue {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        let progress = extendedProgress(byUnitCount: 1)
+        #endif
         
         let future: Future<TaskResult<SuccessValue>> = andThen(upon: executor) { (result) -> Task<SuccessValue> in
+            #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+            progress.becomeCurrent(withPendingUnitCount: 1)
+            defer { progress.resignCurrent() }
+            #endif
+            
             do {
                 let value = try result.extract()
-                return Task<SuccessValue>(success: value)
-            } catch let error {
-                return startNextTask(error)
+                return Task(success: value)
+            } catch {
+                return Task(restartTask(error))
             }
         }
-        
-        return Task<SuccessValue>(future: future)
+
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        return Task<SuccessValue>(future: future, progress: progress)
+        #else
+        return Task<SuccessValue>(future: future, cancellation: cancel)
+        #endif
     }
 }

--- a/Tests/TaskTests/TaskTests.swift
+++ b/Tests/TaskTests/TaskTests.swift
@@ -56,6 +56,7 @@ class TaskTests: CustomExecutorTestCase {
             ("testThatRecoverMapsFailures", testThatRecoverMapsFailures),
             ("testThatMapPassesThroughErrors", testThatMapPassesThroughErrors),
             ("testThatRecoverPassesThroughValues", testThatRecoverPassesThroughValues),
+            ("testThatFallbackAlsoProducesANewTask", testThatFallbackAlsoProducesANewTask)
         ]
 
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
@@ -267,9 +268,11 @@ class TaskTests: CustomExecutorTestCase {
         assertExecutorCalled(atLeast: 1)
     }
     
-    func testThatRecoverAlsoProducesANewTask() {
+    #endif
+    
+    func testThatFallbackAlsoProducesANewTask() {
         let expectation = self.expectation(description: "recover produces a new task")
-        let task: Task<Int> = anyFailedTask.recoverWithNewTask(upon: executor) { _ in
+        let task: Task<Int> = anyFailedTask.fallback(upon: executor) { _ in
             return self.anyFinishedTask
         }
         
@@ -281,6 +284,4 @@ class TaskTests: CustomExecutorTestCase {
         waitForExpectations()
         assertExecutorCalled(2)
     }
-
-    #endif
 }


### PR DESCRIPTION
#### What's in this pull request?

Extends #159. Addresses #149.

Commits the naming change brought up in #159 and takes a simple pass at progress/cancellation from those additions.

#### Testing

Inherits the test from #159.

#### API Changes

Additive.