### PR TITLE
Add a Cocoa-style TaskResult initializer

### DIFF
--- a/Sources/Result/TaskResult.swift
+++ b/Sources/Result/TaskResult.swift
@@ -27,10 +27,26 @@ extension TaskResult: Either {
         self = .failure(error)
     }
 
+    public init(value: Value?, error: Error?) {
+        switch (value, error) {
+        case (let v?, _):
+            // Ignore error if value is non-nil
+            self = .success(v)
+        case (nil, let e?):
+            self = .failure(e)
+        case (nil, nil):
+            self = .failure(TaskResultInitializerError.invalidInput)
+        }
+    }
+
     public func withValues<Return>(ifLeft left: (Error) throws -> Return, ifRight right: (Value) throws -> Return) rethrows -> Return {
         switch self {
         case let .success(value): return try right(value)
         case let .failure(error): return try left(error)
         }
     }
+}
+
+private enum TaskResultInitializerError: Error {
+    case invalidInput
 }

--- a/Tests/ResultTests/TaskResultTests.swift
+++ b/Tests/ResultTests/TaskResultTests.swift
@@ -27,7 +27,10 @@ class TaskResultTests: XCTestCase {
             ("testCoalesceSuccessValue", testCoalesceSuccessValue),
             ("testCoalesceFailureValue", testCoalesceFailureValue),
             ("testFlatCoalesceSuccess", testFlatCoalesceSuccess),
-            ("testFlatCoalesceFailure", testFlatCoalesceFailure)
+            ("testFlatCoalesceSuccess", testFlatCoalesceSuccess),
+            ("testInitializeWithBlockSuccess", testInitializeWithBlockSuccess),
+            ("testInitializeWithBlockError", testInitializeWithBlockError),
+            ("testInitializeWithBlockInitFailure", testInitializeWithBlockInitFailure)
         ]
     }
 
@@ -80,5 +83,24 @@ class TaskResultTests: XCTestCase {
         let x = aFailureResult ?? Result(success: 84)
         XCTAssertEqual(x.value, 84)
         XCTAssertNil(x.error)
+    }
+    
+    func testInitializeWithBlockSuccess() {
+        let result = Result(value: 42, error: nil)
+        XCTAssertEqual(try? result.extract(), 42)
+    }
+
+    func testInitializeWithBlockError() {
+        let result = Result(value: nil, error: TestError.first)
+        guard let error = result.error as? TestError else {
+            XCTFail()
+            return
+        }
+        XCTAssert(error == TestError.first)
+    }
+
+    func testInitializeWithBlockInitFailure() {
+        let result = Result(value: nil, error: nil)
+        XCTAssertNil(try? result.extract())
     }
 }


### PR DESCRIPTION
#### What's in this pull request?
Address https://github.com/bignerdranch/Deferred/issues/168 and add a Cocoa-style Result initializer to `TaskResult`

#### Testing
Added tests for new code and the whole test suite passes locally

Now can we pretty please close 3.0 😬 ?