### PR TITLE
Remove KVO context in private object to quiet 4b3 exclusiveness checker

### DIFF
--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -630,14 +630,18 @@
 				TargetAttributes = {
 					DB126C9F1E53685300054E95 = {
 						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = 439592V3LM;
+						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 					};
 					DB126CA71E53685300054E95 = {
 						CreatedOnToolsVersion = 8.2.1;
+						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 					};
 					DB126CBB1E53685C00054E95 = {
 						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = 439592V3LM;
 						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 					};
@@ -648,6 +652,7 @@
 					};
 					DB126CD71E53686900054E95 = {
 						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = 439592V3LM;
 						ProvisioningStyle = Automatic;
 					};
 					DB126CDF1E53686900054E95 = {
@@ -656,6 +661,7 @@
 					};
 					DB126CF31E53687300054E95 = {
 						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = 439592V3LM;
 						ProvisioningStyle = Automatic;
 					};
 				};

--- a/Tests/AllTestsCommon.swift
+++ b/Tests/AllTestsCommon.swift
@@ -21,6 +21,24 @@ enum TestError: Error {
     case third
 }
 
+#if swift(>=3.2)
+func sleep(_ duration: DispatchTimeInterval) {
+    var t = timespec(tv_sec: 0, tv_nsec: 0)
+    switch duration {
+    case .microseconds(let micro):
+        t.tv_nsec = micro * 1_000
+    case .nanoseconds(let nano):
+        t.tv_nsec = nano
+    case .milliseconds(let millo):
+        t.tv_nsec = millo * 1_000
+    case .seconds(let sec):
+        t.tv_sec = sec
+    case .never:
+        return
+    }
+    nanosleep(&t, nil)
+}
+#else
 func sleep(_ duration: DispatchTimeInterval) {
     var t = timespec(tv_sec: 0, tv_nsec: 0)
     switch duration {
@@ -35,6 +53,7 @@ func sleep(_ duration: DispatchTimeInterval) {
     }
     nanosleep(&t, nil)
 }
+#endif
 
 extension XCTestCase {
     func waitForExpectations(file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
Swift 4 beta 3 activates (or strengthens) the exhaustiveness checker. This hits on taking a global pointer for KVO as a mutable access. The [official recommendation](https://developer.apple.com/library/content/documentation/Swift/Conceptual/BuildingCocoaApps/AdoptingCocoaDesignPatterns.html#//apple_ref/doc/uid/TP40014216-CH7-ID6) appears to be to adopt Swift 4's KVO overlay. Fortunately for us, the observation object doesn't need the context parameter as it's `private final`; `context` exists to help subclass trees.

No API impacts. No compatibility impacts.