### PR TITLE
Allow creating Task with futures that cannot fail

### DIFF
--- a/Sources/Atomics/include/Atomics.h
+++ b/Sources/Atomics/include/Atomics.h
@@ -159,7 +159,7 @@ static inline uint_fast8_t bnr_atomic_bitmask_and(volatile bnr_atomic_bitmask_t 
 }
 
 OS_ALWAYS_INLINE
-static inline bool bnr_atomic_bitmask_test(const bnr_atomic_bitmask_t *_Nonnull target, uint_fast8_t value) {
+static inline bool bnr_atomic_bitmask_test(volatile bnr_atomic_bitmask_t *_Nonnull target, uint_fast8_t value) {
     return (__c11_atomic_load((_Atomic(uint_fast8_t) *)&target->value, __ATOMIC_RELAXED) & value) != 0;
 }
 

--- a/Sources/Task/ResultFuture.swift
+++ b/Sources/Task/ResultFuture.swift
@@ -61,10 +61,10 @@ extension FutureProtocol where Value: Either {
     }
 }
 
-extension Future where Value: Either {
+extension Future where Value: Either, Value.Left == Error {
     /// Create a future having the same underlying task as `other`.
     public init<Other: FutureProtocol>(task other: Other)
-        where Other.Value: Either, Other.Value.Left == Error, Other.Value.Right == Value.Right {
+        where Other.Value: Either, Other.Value.Left == Value.Left, Other.Value.Right == Value.Right {
         if let asSelf = other as? Future<Value> {
             self.init(asSelf)
         } else {
@@ -72,5 +72,13 @@ extension Future where Value: Either {
                 Value(from: $0.extract)
             })
         }
+    }
+
+    /// Create a future having the same underlying task as `other`.
+    public init<Other: FutureProtocol>(success other: Other)
+        where Other.Value == Value.Right {
+        self.init(other.every {
+            Value(success: $0)
+        })
     }
 }

--- a/Sources/Task/TaskCollections.swift
+++ b/Sources/Task/TaskCollections.swift
@@ -43,7 +43,7 @@ extension Collection where Iterator.Element: FutureProtocol, Iterator.Element.Va
             if let task = future as? Task<Iterator.Element.Value.Right> {
                 progress.adoptChild(task.progress, orphaned: false, pendingUnitCount: 1)
             } else {
-                progress.adoptChild(.wrapped(future, cancellation: nil), orphaned: true, pendingUnitCount: 1)
+                progress.adoptChild(.wrappingSuccess(of: future, cancellation: nil), orphaned: true, pendingUnitCount: 1)
             }
             #else
             if let task = future as? Task<Iterator.Element.Value.Right> {

--- a/Tests/TaskTests/TaskTests.swift
+++ b/Tests/TaskTests/TaskTests.swift
@@ -290,4 +290,19 @@ class TaskTests: CustomExecutorTestCase {
         waitForExpectations()
         assertExecutorCalled(2)
     }
+
+    func testSimpleFutureCanBeUpgradedToTask() {
+        let expectation = self.expectation(description: "original future filled")
+        let deferred = Deferred<Int>()
+        let task = Task<Int>(success: deferred, cancellation: nil)
+
+        task.uponSuccess { (value) in
+            XCTAssertEqual(value, 42)
+            expectation.fulfill()
+        }
+
+        deferred.fill(with: 42)
+        waitForExpectations()
+    }
+
 }


### PR DESCRIPTION
#### What's in this pull request?

Adds `Task.init(success: Future<Result.Right>, …)` constructors with cancellation and progress support.

#### Testing

- [x] Test pass needed.

#### API Changes

Additive only.