### PR TITLE
Remove playground descriptions, improve reflection

### DIFF
--- a/Sources/Deferred/Future.swift
+++ b/Sources/Deferred/Future.swift
@@ -30,7 +30,7 @@ public typealias PreferredExecutor = DispatchQueue
 /// access, though ideally all members of the future could be called from any
 /// thread.
 ///
-public protocol FutureProtocol: CustomDebugStringConvertible, CustomReflectable, CustomPlaygroundQuickLookable {
+public protocol FutureProtocol: CustomDebugStringConvertible, CustomReflectable {
     /// A type that represents the result of some asynchronous operation.
     associatedtype Value
 
@@ -155,11 +155,6 @@ extension FutureProtocol {
         case let value:
             return Mirror(self, children: [ "isFilled": value != nil ], displayStyle: .tuple)
         }
-    }
-
-    /// A custom playground Quick Look for this instance.
-    public var customPlaygroundQuickLook: PlaygroundQuickLook {
-        return PlaygroundQuickLook(reflecting: peek() as Any)
     }
 }
 

--- a/Sources/Deferred/Future.swift
+++ b/Sources/Deferred/Future.swift
@@ -136,24 +136,26 @@ extension FutureProtocol {
 extension FutureProtocol {
     /// A textual representation of this instance, suitable for debugging.
     public var debugDescription: String {
-        var ret = "\(Self.self)"
-        if Value.self == Void.self && isFilled {
-            ret += " (filled)"
+        var ret = ""
+        ret.append(contentsOf: "\(Self.self)".prefix(while: { $0 != "<" }))
+        ret.append("(")
+        if Value.self == Void.self, isFilled {
+            ret.append("filled")
         } else if let value = peek() {
-            ret += "(\(String(reflecting: value)))"
+            debugPrint(value, terminator: "", to: &ret)
         } else {
-            ret += " (not filled)"
+            ret.append("not filled")
         }
+        ret.append(")")
         return ret
     }
 
     /// Return the `Mirror` for `self`.
     public var customMirror: Mirror {
-        switch peek() {
-        case let value? where Value.self != Void.self:
+        if Value.self != Void.self, let value = peek() {
             return Mirror(self, children: [ "value": value ], displayStyle: .optional)
-        case let value:
-            return Mirror(self, children: [ "isFilled": value != nil ], displayStyle: .tuple)
+        } else {
+            return Mirror(self, children: [ "isFilled": peek() != nil ], displayStyle: .tuple)
         }
     }
 }

--- a/Sources/Deferred/Protected.swift
+++ b/Sources/Deferred/Protected.swift
@@ -39,14 +39,19 @@ public final class Protected<T> {
 
 extension Protected: CustomDebugStringConvertible, CustomReflectable {
     public var debugDescription: String {
-        return lock.withAttemptedReadLock {
-            "\(type(of: self))(\(String(reflecting: unsafeValue)))"
-        } ?? "\(type(of: self)) (lock contended)"
+        var ret = "Protected("
+        if lock.withAttemptedReadLock({
+            debugPrint(unsafeValue, terminator: "", to: &ret)
+        }) == nil {
+            ret.append("locked")
+        }
+        ret.append(")")
+        return ret
     }
 
     public var customMirror: Mirror {
         return lock.withAttemptedReadLock {
-            Mirror(self, children: [ "item": unsafeValue ], displayStyle: .optional)
-        } ?? Mirror(self, children: [ "lockContended": true ], displayStyle: .tuple)
+            Mirror(self, unlabeledChildren: [ unsafeValue ], displayStyle: .optional)
+        } ?? Mirror(self, children: [ "locked": true ], displayStyle: .tuple)
     }
 }

--- a/Sources/Deferred/Protected.swift
+++ b/Sources/Deferred/Protected.swift
@@ -37,7 +37,7 @@ public final class Protected<T> {
     }
 }
 
-extension Protected: CustomDebugStringConvertible, CustomReflectable, CustomPlaygroundQuickLookable {
+extension Protected: CustomDebugStringConvertible, CustomReflectable {
     public var debugDescription: String {
         return lock.withAttemptedReadLock {
             "\(type(of: self))(\(String(reflecting: unsafeValue)))"
@@ -48,9 +48,5 @@ extension Protected: CustomDebugStringConvertible, CustomReflectable, CustomPlay
         return lock.withAttemptedReadLock {
             Mirror(self, children: [ "item": unsafeValue ], displayStyle: .optional)
         } ?? Mirror(self, children: [ "lockContended": true ], displayStyle: .tuple)
-    }
-
-    public var customPlaygroundQuickLook: PlaygroundQuickLook {
-        return PlaygroundQuickLook(reflecting: lock.withAttemptedReadLock({ unsafeValue }) as Any)
     }
 }

--- a/Tests/DeferredTests/DeferredTests.swift
+++ b/Tests/DeferredTests/DeferredTests.swift
@@ -39,7 +39,13 @@ class DeferredTests: XCTestCase {
             ("testIsFilledCanBeCalledMultipleTimesNotFilled", testIsFilledCanBeCalledMultipleTimesNotFilled),
             ("testIsFilledCanBeCalledMultipleTimesWhenFilled", testIsFilledCanBeCalledMultipleTimesWhenFilled),
             ("testFillAndIsFilledPostcondition", testFillAndIsFilledPostcondition),
-            ("testSimultaneousFill", testSimultaneousFill)
+            ("testSimultaneousFill", testSimultaneousFill),
+            ("testDebugDescriptionUnfilled", testDebugDescriptionUnfilled),
+            ("testDebugDescriptionFilled", testDebugDescriptionFilled),
+            ("testDebugDescriptionFilledWhenValueIsVoid", testDebugDescriptionFilledWhenValueIsVoid),
+            ("testReflectionUnfilled", testReflectionUnfilled),
+            ("testReflectionFilled", testReflectionFilled),
+            ("testReflectionFilledWhenValueIsVoid", testReflectionFilledWhenValueIsVoid)
         ]
 
         #if os(OSX) || (os(iOS) && !(arch(i386) || arch(x86_64))) || (os(watchOS) && !(arch(i386) || arch(x86_64))) || (os(tvOS) && !arch(x86_64))
@@ -370,6 +376,48 @@ class DeferredTests: XCTestCase {
         startGroup.leave()
         XCTAssertEqual(finishGroup.wait(timeout: .distantFuture), .success)
         waitForExpectationsShort()
+    }
+
+    func testDebugDescriptionUnfilled() {
+        let deferred = Deferred<Int>()
+        XCTAssertEqual("\(deferred)", "Deferred(not filled)")
+    }
+
+    func testDebugDescriptionFilled() {
+        let deferred = Deferred<Int>(filledWith: 42)
+        XCTAssertEqual("\(deferred)", "Deferred(42)")
+    }
+
+    func testDebugDescriptionFilledWhenValueIsVoid() {
+        let deferred = Deferred<Void>(filledWith: ())
+        XCTAssertEqual("\(deferred)", "Deferred(filled)")
+    }
+
+    func testReflectionUnfilled() {
+        let deferred = Deferred<Int>()
+
+        let magicMirror = Mirror(reflecting: deferred)
+        XCTAssertEqual(magicMirror.displayStyle, .tuple)
+        XCTAssertNil(magicMirror.superclassMirror)
+        XCTAssertEqual(magicMirror.descendant("isFilled") as? Bool, false)
+    }
+
+    func testReflectionFilled() {
+        let deferred = Deferred<Int>(filledWith: 42)
+
+        let magicMirror = Mirror(reflecting: deferred)
+        XCTAssertEqual(magicMirror.displayStyle, .optional)
+        XCTAssertNil(magicMirror.superclassMirror)
+        XCTAssertEqual(magicMirror.descendant(0) as? Int, 42)
+    }
+
+    func testReflectionFilledWhenValueIsVoid() {
+        let deferred = Deferred<Void>(filledWith: ())
+
+        let magicMirror = Mirror(reflecting: deferred)
+        XCTAssertEqual(magicMirror.displayStyle, .tuple)
+        XCTAssertNil(magicMirror.superclassMirror)
+        XCTAssertEqual(magicMirror.descendant("isFilled") as? Bool, true)
     }
 }
 

--- a/Tests/DeferredTests/ExistentialFutureTests.swift
+++ b/Tests/DeferredTests/ExistentialFutureTests.swift
@@ -10,15 +10,19 @@ import XCTest
 @testable import Deferred
 
 class ExistentialFutureTests: XCTestCase {
-    static var allTests: [(String, (ExistentialFutureTests) -> () throws -> Void)] {
-        return [
-            ("testFilledAnyFutureWaitAlwaysReturns", testFilledAnyFutureWaitAlwaysReturns),
-            ("testAnyWaitWithTimeout", testAnyWaitWithTimeout),
-            ("testFilledAnyFutureUpon", testFilledAnyFutureUpon),
-            ("testUnfilledAnyUponCalledWhenFilled", testUnfilledAnyUponCalledWhenFilled),
-            ("testFillAndIsFilledPostcondition", testFillAndIsFilledPostcondition)
-        ]
-    }
+    static let allTests: [(String, (ExistentialFutureTests) -> () throws -> Void)] = [
+        ("testFilledAnyFutureWaitAlwaysReturns", testFilledAnyFutureWaitAlwaysReturns),
+        ("testAnyWaitWithTimeout", testAnyWaitWithTimeout),
+        ("testFilledAnyFutureUpon", testFilledAnyFutureUpon),
+        ("testUnfilledAnyUponCalledWhenFilled", testUnfilledAnyUponCalledWhenFilled),
+        ("testFillAndIsFilledPostcondition", testFillAndIsFilledPostcondition),
+        ("testDebugDescriptionUnfilled", testDebugDescriptionUnfilled),
+        ("testDebugDescriptionFilled", testDebugDescriptionFilled),
+        ("testDebugDescriptionFilledWhenValueIsVoid", testDebugDescriptionFilledWhenValueIsVoid),
+        ("testReflectionUnfilled", testReflectionUnfilled),
+        ("testReflectionFilled", testReflectionFilled),
+        ("testReflectionFilledWhenValueIsVoid", testReflectionFilledWhenValueIsVoid)
+    ]
 
     var anyFuture: Future<Int>!
 
@@ -91,5 +95,47 @@ class ExistentialFutureTests: XCTestCase {
         XCTAssertTrue(anyFuture.isFilled)
         XCTAssertNotNil(anyFuture.wait(until: .now()))
         XCTAssertNotNil(anyFuture.waitShort())  // pass
+    }
+
+    func testDebugDescriptionUnfilled() {
+        let future = Future<Int>()
+        XCTAssertEqual("\(future)", "Future(not filled)")
+    }
+
+    func testDebugDescriptionFilled() {
+        let future = Future<Int>(value: 42)
+        XCTAssertEqual("\(future)", "Future(42)")
+    }
+
+    func testDebugDescriptionFilledWhenValueIsVoid() {
+        let future = Future<Void>(value: ())
+        XCTAssertEqual("\(future)", "Future(filled)")
+    }
+
+    func testReflectionUnfilled() {
+        let future = Future<Int>()
+
+        let magicMirror = Mirror(reflecting: future)
+        XCTAssertEqual(magicMirror.displayStyle, .tuple)
+        XCTAssertNil(magicMirror.superclassMirror)
+        XCTAssertEqual(magicMirror.descendant("isFilled") as? Bool, false)
+    }
+
+    func testReflectionFilled() {
+        let future = Future<Int>(value: 42)
+
+        let magicMirror = Mirror(reflecting: future)
+        XCTAssertEqual(magicMirror.displayStyle, .optional)
+        XCTAssertNil(magicMirror.superclassMirror)
+        XCTAssertEqual(magicMirror.descendant(0) as? Int, 42)
+    }
+
+    func testReflectionFilledWhenValueIsVoid() {
+        let future = Future<Void>(value: ())
+
+        let magicMirror = Mirror(reflecting: future)
+        XCTAssertEqual(magicMirror.displayStyle, .tuple)
+        XCTAssertNil(magicMirror.superclassMirror)
+        XCTAssertEqual(magicMirror.descendant("isFilled") as? Bool, true)
     }
 }


### PR DESCRIPTION
#### What's in this pull request?

Removes `CustomPlaygroundQuickLookable` in preparation for Swift 5. Improves our `debugDescription`s and `customMirror`s.

#### Testing

Improves test coverage slightly.

#### API Changes

Removals, but of compiler APIs - nothing that a client should've been using.