### PR TITLE
Fix import of TaskGroup.init()

### DIFF
--- a/Sources/Task/TaskGroup.swift
+++ b/Sources/Task/TaskGroup.swift
@@ -3,7 +3,7 @@
 //  Deferred
 //
 //  Created by John Gallagher on 8/18/15.
-//  Copyright © 2015-2016 Big Nerd Ranch. Licensed under MIT.
+//  Copyright © 2015-2018 Big Nerd Ranch. Licensed under MIT.
 //
 
 #if SWIFT_PACKAGE
@@ -19,7 +19,9 @@ import Dispatch
 /// The success or failure of the accumulated tasks is ignored - this type is
 /// only interested in completion.
 public struct TaskGroup {
+
     private let group = DispatchGroup()
+    public init() {}
 
     private var queue: DispatchQueue {
         return .global(qos: .utility)

--- a/Tests/TaskTests/TaskGroupTests.swift
+++ b/Tests/TaskTests/TaskGroupTests.swift
@@ -3,7 +3,7 @@
 //  DeferredTests
 //
 //  Created by John Gallagher on 8/18/15.
-//  Copyright © 2015-2016 Big Nerd Ranch. Licensed under MIT.
+//  Copyright © 2015-2018 Big Nerd Ranch. Licensed under MIT.
 //
 
 import XCTest
@@ -11,17 +11,15 @@ import Dispatch
 
 #if SWIFT_PACKAGE
 import Deferred
-@testable import Task
+import Task
 #else
-@testable import Deferred
+import Deferred
 #endif
 
 class TaskGroupTests: XCTestCase {
-    static var allTests: [(String, (TaskGroupTests) -> () throws -> Void)] {
-        return [
-            ("testThatAllCompleteTaskWaitsForAllAccumulatedTasks", testThatAllCompleteTaskWaitsForAllAccumulatedTasks)
-        ]
-    }
+    static let allTests: [(String, (TaskGroupTests) -> () throws -> Void)] = [
+        ("testThatAllCompleteTaskWaitsForAllAccumulatedTasks", testThatAllCompleteTaskWaitsForAllAccumulatedTasks)
+    ]
 
     private let queue = DispatchQueue(label: "TaskGroupTests", attributes: .concurrent)
     private var accumulator: TaskGroup!
@@ -55,13 +53,13 @@ class TaskGroupTests: XCTestCase {
             }
         }
 
-        let expectation = self.expectation(description: "allCompleteTask finished")
-        accumulator.completed().upon(queue) { [weak expectation] _ in
+        let expect = expectation(description: "allCompleteTask finished")
+        accumulator.completed().upon(queue) { _ in
             for task in tasks {
                 XCTAssertNotNil(task.wait(until: .distantFuture))
             }
 
-            expectation?.fulfill()
+            expect.fulfill()
         }
 
         waitForExpectations()


### PR DESCRIPTION
#### What's in this pull request?

Fixes an export.

#### Testing

No changes.

#### API Changes

Explicitly publishes an `init()` that was implicit before.