### PR TITLE
Require `Executor` be a class type

### DIFF
--- a/Sources/Deferred/Executor.swift
+++ b/Sources/Deferred/Executor.swift
@@ -43,7 +43,7 @@ import Foundation
 ///         Person(json: json, inContext: context)
 ///     }
 ///
-public protocol Executor {
+public protocol Executor: class {
     /// Execute the `body` closure.
     func submit(_ body: @escaping() -> Void)
 
@@ -54,8 +54,6 @@ public protocol Executor {
     /// may be used instead of `submit(_:)` for more efficient execution.
     var underlyingQueue: DispatchQueue? { get }
 }
-
-public typealias DefaultExecutor = DispatchQueue
 
 extension Executor {
     /// By default, submits the closure contents of the work item.
@@ -102,6 +100,8 @@ extension DispatchQueue: Executor {
         return self
     }
 }
+
+public typealias DefaultExecutor = DispatchQueue
 
 /// An operation queue manages a number of operation objects, making high
 /// level features like cancellation and dependencies simple.

--- a/Tests/DeferredTests/LockingTests.swift
+++ b/Tests/DeferredTests/LockingTests.swift
@@ -113,7 +113,7 @@ class LockingTests: XCTestCase {
     }
 
     func testSingleThreadPerformanceRead() {
-        let iterations = 250_000
+        let iterations = 100_000
         func doNothing() {}
 
         measure {
@@ -124,7 +124,7 @@ class LockingTests: XCTestCase {
     }
 
     func testSingleThreadPerformanceWrite() {
-        let iterations = 250_000
+        let iterations = 100_000
         func doNothing() {}
 
         measure {
@@ -135,7 +135,7 @@ class LockingTests: XCTestCase {
     }
 
     func test90PercentReads4ThreadsLock() {
-        let iterations = 5000
+        let iterations = 100_000
         let numberOfThreads = max(ProcessInfo.processInfo.processorCount, 2)
         let group = DispatchGroup()
         func doNothing() {}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->

#### What's in this pull request?

Now that `Dispatch` types are classes, we can model `Executor` the way we always wanted to, which also has the benefit of a more efficient memory layout.

#### Testing

No changes to coverage, but some linter gardening.

#### API Changes

This is a breaking change to `Executor`, but one that would've been pretty difficult to implement before.