### PR TITLE
Improve debug printing, mustFill reporting

### DIFF
--- a/Sources/Deferred/Future.swift
+++ b/Sources/Deferred/Future.swift
@@ -152,11 +152,14 @@ extension FutureProtocol {
 
     /// Return the `Mirror` for `self`.
     public var customMirror: Mirror {
-        guard Value.self != Void.self, let value = peek() else {
-            return Mirror(self, children: [ "isFilled": peek() != nil ], displayStyle: .tuple)
+        let child: Mirror.Child
+        switch peek() {
+        case let value? where Value.self != Void.self:
+            child = (label: "value", value: value)
+        case let other:
+            child = (label: "isFilled", value: other != nil)
         }
-
-        return Mirror(self, unlabeledChildren: [ value ], displayStyle: .optional)
+        return Mirror(self, children: CollectionOfOne(child), displayStyle: .optional, ancestorRepresentation: .suppressed)
     }
 }
 

--- a/Sources/Deferred/Promise.swift
+++ b/Sources/Deferred/Promise.swift
@@ -51,9 +51,9 @@ extension PromiseProtocol {
     ///   is a serious programming error. The optimizer may assume that it is
     ///   not possible.
     @_transparent
-    public func mustFill(with value: Value) {
+    public func mustFill(with value: Value, file: StaticString = #file, line: UInt = #line) {
         if !fill(with: value) {
-            preconditionFailure("Cannot fill an already-filled \(type(of: self))")
+            preconditionFailure("Cannot fill an already-filled \(type(of: self))", file: file, line: line)
         }
     }
 }

--- a/Sources/Deferred/Protected.swift
+++ b/Sources/Deferred/Protected.swift
@@ -50,8 +50,10 @@ extension Protected: CustomDebugStringConvertible, CustomReflectable {
     }
 
     public var customMirror: Mirror {
-        return lock.withAttemptedReadLock {
-            Mirror(self, unlabeledChildren: [ unsafeValue ], displayStyle: .optional)
-        } ?? Mirror(self, children: [ "locked": true ], displayStyle: .tuple)
+        let child: Mirror.Child = lock.withAttemptedReadLock {
+            (label: "value", value: unsafeValue)
+        } ?? (label: "isLocked", value: true)
+        return Mirror(self, children: CollectionOfOne(child), displayStyle: .optional)
+
     }
 }

--- a/Tests/DeferredTests/DeferredTests.swift
+++ b/Tests/DeferredTests/DeferredTests.swift
@@ -376,7 +376,7 @@ class DeferredTests: XCTestCase {
         let deferred = Deferred<Int>()
 
         let magicMirror = Mirror(reflecting: deferred)
-        XCTAssertEqual(magicMirror.displayStyle, .tuple)
+        XCTAssertEqual(magicMirror.displayStyle, .optional)
         XCTAssertNil(magicMirror.superclassMirror)
         XCTAssertEqual(magicMirror.descendant("isFilled") as? Bool, false)
     }
@@ -394,7 +394,7 @@ class DeferredTests: XCTestCase {
         let deferred = Deferred<Void>(filledWith: ())
 
         let magicMirror = Mirror(reflecting: deferred)
-        XCTAssertEqual(magicMirror.displayStyle, .tuple)
+        XCTAssertEqual(magicMirror.displayStyle, .optional)
         XCTAssertNil(magicMirror.superclassMirror)
         XCTAssertEqual(magicMirror.descendant("isFilled") as? Bool, true)
     }

--- a/Tests/DeferredTests/ExistentialFutureTests.swift
+++ b/Tests/DeferredTests/ExistentialFutureTests.swift
@@ -114,7 +114,7 @@ class ExistentialFutureTests: XCTestCase {
         let future = Future<Int>()
 
         let magicMirror = Mirror(reflecting: future)
-        XCTAssertEqual(magicMirror.displayStyle, .tuple)
+        XCTAssertEqual(magicMirror.displayStyle, .optional)
         XCTAssertNil(magicMirror.superclassMirror)
         XCTAssertEqual(magicMirror.descendant("isFilled") as? Bool, false)
     }
@@ -132,7 +132,7 @@ class ExistentialFutureTests: XCTestCase {
         let future = Future<Void>(value: ())
 
         let magicMirror = Mirror(reflecting: future)
-        XCTAssertEqual(magicMirror.displayStyle, .tuple)
+        XCTAssertEqual(magicMirror.displayStyle, .optional)
         XCTAssertNil(magicMirror.superclassMirror)
         XCTAssertEqual(magicMirror.descendant("isFilled") as? Bool, true)
     }

--- a/Tests/DeferredTests/ProtectedTests.swift
+++ b/Tests/DeferredTests/ProtectedTests.swift
@@ -112,9 +112,9 @@ class ProtectedTests: XCTestCase {
         defer { customLock.unlock() }
 
         let magicMirror = Mirror(reflecting: protected)
-        XCTAssertEqual(magicMirror.displayStyle, .tuple)
+        XCTAssertEqual(magicMirror.displayStyle, .optional)
         XCTAssertNil(magicMirror.superclassMirror)
-        XCTAssertEqual(magicMirror.descendant("locked") as? Bool, true)
+        XCTAssertEqual(magicMirror.descendant("isLocked") as? Bool, true)
     }
 
 }


### PR DESCRIPTION
#### What's in this pull request?

What it says on the tin.

* `po emptyDeferred` (or similar for a `Future`, `Protected`) no longer includes `▿ elements: 1`
* `po task` no longer includes references to `NSObject`.
* `PromiseProtocol.mustFill(with:)` correctly reports its failure location in a client codebase.

#### Testing

Minor selfsame changes to places that explicitly tested values coming out of `Mirror`.

#### API Changes

Restores defaulted `file` and `line` parameters.