### PR TITLE
Declutter Future protocol

### DIFF
--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -173,6 +173,14 @@
 		DBA01AFF2071E5D300083CD0 /* FutureUpon.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01AFD2071E5D300083CD0 /* FutureUpon.swift */; };
 		DBA01B002071E5D300083CD0 /* FutureUpon.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01AFD2071E5D300083CD0 /* FutureUpon.swift */; };
 		DBA01B012071E5D300083CD0 /* FutureUpon.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01AFD2071E5D300083CD0 /* FutureUpon.swift */; };
+		DBA01B042071E69100083CD0 /* FutureMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B022071E68F00083CD0 /* FutureMap.swift */; };
+		DBA01B052071E69100083CD0 /* FutureMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B022071E68F00083CD0 /* FutureMap.swift */; };
+		DBA01B062071E69100083CD0 /* FutureMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B022071E68F00083CD0 /* FutureMap.swift */; };
+		DBA01B072071E69100083CD0 /* FutureMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B022071E68F00083CD0 /* FutureMap.swift */; };
+		DBA01B082071E69100083CD0 /* FutureAndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B032071E68F00083CD0 /* FutureAndThen.swift */; };
+		DBA01B092071E69100083CD0 /* FutureAndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B032071E68F00083CD0 /* FutureAndThen.swift */; };
+		DBA01B0A2071E69100083CD0 /* FutureAndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B032071E68F00083CD0 /* FutureAndThen.swift */; };
+		DBA01B0B2071E69100083CD0 /* FutureAndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B032071E68F00083CD0 /* FutureAndThen.swift */; };
 		DBABD0BB203F2E3E00C50896 /* Atomics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBABD0BA203F2E3E00C50896 /* Atomics.swift */; };
 		DBABD0BC203F2E3E00C50896 /* Atomics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBABD0BA203F2E3E00C50896 /* Atomics.swift */; };
 		DBABD0BD203F2E3E00C50896 /* Atomics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBABD0BA203F2E3E00C50896 /* Atomics.swift */; };
@@ -262,6 +270,8 @@
 		DB55F20B1D969A1B00FC1439 /* FutureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureTests.swift; sourceTree = "<group>"; };
 		DB8A071B2060D38C00639AB3 /* PerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		DBA01AFD2071E5D300083CD0 /* FutureUpon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureUpon.swift; sourceTree = "<group>"; };
+		DBA01B022071E68F00083CD0 /* FutureMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureMap.swift; sourceTree = "<group>"; };
+		DBA01B032071E68F00083CD0 /* FutureAndThen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureAndThen.swift; sourceTree = "<group>"; };
 		DBABD0BA203F2E3E00C50896 /* Atomics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomics.swift; sourceTree = "<group>"; };
 		DBC742631DC2F6D4002FB30D /* FutureEveryMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureEveryMap.swift; sourceTree = "<group>"; };
 		EBEB828C1DC4A79A00B7E089 /* TaskComprehensiveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskComprehensiveTests.swift; sourceTree = "<group>"; };
@@ -380,10 +390,12 @@
 				DB524C941D85200C00DDF16D /* Executor.swift */,
 				DB524C951D85200C00DDF16D /* ExistentialFuture.swift */,
 				DB524C9A1D85200C00DDF16D /* Future.swift */,
+				DBA01B032071E68F00083CD0 /* FutureAndThen.swift */,
 				DB524C961D85200C00DDF16D /* FutureCollections.swift */,
 				DB524C971D85200C00DDF16D /* FutureComposition.swift */,
 				DBC742631DC2F6D4002FB30D /* FutureEveryMap.swift */,
 				DB524C9B1D85200C00DDF16D /* FutureIgnore.swift */,
+				DBA01B022071E68F00083CD0 /* FutureMap.swift */,
 				DBA01AFD2071E5D300083CD0 /* FutureUpon.swift */,
 				DB524C9F1D85200C00DDF16D /* Locking.swift */,
 				DB524C9E1D85200C00DDF16D /* Promise.swift */,
@@ -761,6 +773,7 @@
 				DB126CFD1E5368A100054E95 /* Executor.swift in Sources */,
 				DB126D2A1E5368A700054E95 /* TaskResult.swift in Sources */,
 				DB126D021E5368A100054E95 /* FutureEveryMap.swift in Sources */,
+				DBA01B082071E69100083CD0 /* FutureAndThen.swift in Sources */,
 				DB126CFE1E5368A100054E95 /* ExistentialFuture.swift in Sources */,
 				DBABD0BB203F2E3E00C50896 /* Atomics.swift in Sources */,
 				DB126D341E5368AD00054E95 /* ExistentialTask.swift in Sources */,
@@ -780,6 +793,7 @@
 				DB126D391E5368AD00054E95 /* TaskGroup.swift in Sources */,
 				DB126CFC1E5368A100054E95 /* Deferred.swift in Sources */,
 				DB126D051E5368A100054E95 /* Promise.swift in Sources */,
+				DBA01B042071E69100083CD0 /* FutureMap.swift in Sources */,
 				DB126D001E5368A100054E95 /* FutureCollections.swift in Sources */,
 				DB126D011E5368A100054E95 /* FutureComposition.swift in Sources */,
 				DB126D371E5368AD00054E95 /* TaskAndThen.swift in Sources */,
@@ -819,6 +833,7 @@
 				DB126D081E5368A100054E95 /* Executor.swift in Sources */,
 				DB126D2D1E5368A700054E95 /* TaskResult.swift in Sources */,
 				DB126D0D1E5368A100054E95 /* FutureEveryMap.swift in Sources */,
+				DBA01B092071E69100083CD0 /* FutureAndThen.swift in Sources */,
 				DB126D091E5368A100054E95 /* ExistentialFuture.swift in Sources */,
 				DB126D3F1E5368AD00054E95 /* ExistentialTask.swift in Sources */,
 				DB126D111E5368A100054E95 /* Protected.swift in Sources */,
@@ -838,6 +853,7 @@
 				DB126D071E5368A100054E95 /* Deferred.swift in Sources */,
 				DBABD0BC203F2E3E00C50896 /* Atomics.swift in Sources */,
 				DB126D101E5368A100054E95 /* Promise.swift in Sources */,
+				DBA01B052071E69100083CD0 /* FutureMap.swift in Sources */,
 				DB126D0B1E5368A100054E95 /* FutureCollections.swift in Sources */,
 				DB126D0C1E5368A100054E95 /* FutureComposition.swift in Sources */,
 				DB126D421E5368AD00054E95 /* TaskAndThen.swift in Sources */,
@@ -877,6 +893,7 @@
 				DB126D131E5368A200054E95 /* Executor.swift in Sources */,
 				DB126D301E5368A800054E95 /* TaskResult.swift in Sources */,
 				DB126D181E5368A200054E95 /* FutureEveryMap.swift in Sources */,
+				DBA01B0A2071E69100083CD0 /* FutureAndThen.swift in Sources */,
 				DB126D141E5368A200054E95 /* ExistentialFuture.swift in Sources */,
 				DB126D4A1E5368AE00054E95 /* ExistentialTask.swift in Sources */,
 				DB126D1C1E5368A200054E95 /* Protected.swift in Sources */,
@@ -896,6 +913,7 @@
 				DB126D121E5368A200054E95 /* Deferred.swift in Sources */,
 				DBABD0BD203F2E3E00C50896 /* Atomics.swift in Sources */,
 				DB126D1B1E5368A200054E95 /* Promise.swift in Sources */,
+				DBA01B062071E69100083CD0 /* FutureMap.swift in Sources */,
 				DB126D161E5368A200054E95 /* FutureCollections.swift in Sources */,
 				DB126D171E5368A200054E95 /* FutureComposition.swift in Sources */,
 				DB126D4D1E5368AE00054E95 /* TaskAndThen.swift in Sources */,
@@ -935,6 +953,7 @@
 				DB126D1E1E5368A200054E95 /* Executor.swift in Sources */,
 				DB126D331E5368A900054E95 /* TaskResult.swift in Sources */,
 				DB126D231E5368A200054E95 /* FutureEveryMap.swift in Sources */,
+				DBA01B0B2071E69100083CD0 /* FutureAndThen.swift in Sources */,
 				DB126D1F1E5368A200054E95 /* ExistentialFuture.swift in Sources */,
 				DB126D551E5368AE00054E95 /* ExistentialTask.swift in Sources */,
 				DB126D271E5368A200054E95 /* Protected.swift in Sources */,
@@ -954,6 +973,7 @@
 				DB126D1D1E5368A200054E95 /* Deferred.swift in Sources */,
 				DBABD0BE203F2E3E00C50896 /* Atomics.swift in Sources */,
 				DB126D261E5368A200054E95 /* Promise.swift in Sources */,
+				DBA01B072071E69100083CD0 /* FutureMap.swift in Sources */,
 				DB126D211E5368A200054E95 /* FutureCollections.swift in Sources */,
 				DB126D221E5368A200054E95 /* FutureComposition.swift in Sources */,
 				DB126D581E5368AE00054E95 /* TaskAndThen.swift in Sources */,

--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -181,6 +181,10 @@
 		DBA01B092071E69100083CD0 /* FutureAndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B032071E68F00083CD0 /* FutureAndThen.swift */; };
 		DBA01B0A2071E69100083CD0 /* FutureAndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B032071E68F00083CD0 /* FutureAndThen.swift */; };
 		DBA01B0B2071E69100083CD0 /* FutureAndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B032071E68F00083CD0 /* FutureAndThen.swift */; };
+		DBA01B0D2071E6FF00083CD0 /* FuturePeek.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B0C2071E6FF00083CD0 /* FuturePeek.swift */; };
+		DBA01B0E2071E6FF00083CD0 /* FuturePeek.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B0C2071E6FF00083CD0 /* FuturePeek.swift */; };
+		DBA01B0F2071E6FF00083CD0 /* FuturePeek.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B0C2071E6FF00083CD0 /* FuturePeek.swift */; };
+		DBA01B102071E6FF00083CD0 /* FuturePeek.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01B0C2071E6FF00083CD0 /* FuturePeek.swift */; };
 		DBABD0BB203F2E3E00C50896 /* Atomics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBABD0BA203F2E3E00C50896 /* Atomics.swift */; };
 		DBABD0BC203F2E3E00C50896 /* Atomics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBABD0BA203F2E3E00C50896 /* Atomics.swift */; };
 		DBABD0BD203F2E3E00C50896 /* Atomics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBABD0BA203F2E3E00C50896 /* Atomics.swift */; };
@@ -272,6 +276,7 @@
 		DBA01AFD2071E5D300083CD0 /* FutureUpon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureUpon.swift; sourceTree = "<group>"; };
 		DBA01B022071E68F00083CD0 /* FutureMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureMap.swift; sourceTree = "<group>"; };
 		DBA01B032071E68F00083CD0 /* FutureAndThen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureAndThen.swift; sourceTree = "<group>"; };
+		DBA01B0C2071E6FF00083CD0 /* FuturePeek.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FuturePeek.swift; sourceTree = "<group>"; };
 		DBABD0BA203F2E3E00C50896 /* Atomics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomics.swift; sourceTree = "<group>"; };
 		DBC742631DC2F6D4002FB30D /* FutureEveryMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureEveryMap.swift; sourceTree = "<group>"; };
 		EBEB828C1DC4A79A00B7E089 /* TaskComprehensiveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskComprehensiveTests.swift; sourceTree = "<group>"; };
@@ -396,6 +401,7 @@
 				DBC742631DC2F6D4002FB30D /* FutureEveryMap.swift */,
 				DB524C9B1D85200C00DDF16D /* FutureIgnore.swift */,
 				DBA01B022071E68F00083CD0 /* FutureMap.swift */,
+				DBA01B0C2071E6FF00083CD0 /* FuturePeek.swift */,
 				DBA01AFD2071E5D300083CD0 /* FutureUpon.swift */,
 				DB524C9F1D85200C00DDF16D /* Locking.swift */,
 				DB524C9E1D85200C00DDF16D /* Promise.swift */,
@@ -774,6 +780,7 @@
 				DB126D2A1E5368A700054E95 /* TaskResult.swift in Sources */,
 				DB126D021E5368A100054E95 /* FutureEveryMap.swift in Sources */,
 				DBA01B082071E69100083CD0 /* FutureAndThen.swift in Sources */,
+				DBA01B0D2071E6FF00083CD0 /* FuturePeek.swift in Sources */,
 				DB126CFE1E5368A100054E95 /* ExistentialFuture.swift in Sources */,
 				DBABD0BB203F2E3E00C50896 /* Atomics.swift in Sources */,
 				DB126D341E5368AD00054E95 /* ExistentialTask.swift in Sources */,
@@ -834,6 +841,7 @@
 				DB126D2D1E5368A700054E95 /* TaskResult.swift in Sources */,
 				DB126D0D1E5368A100054E95 /* FutureEveryMap.swift in Sources */,
 				DBA01B092071E69100083CD0 /* FutureAndThen.swift in Sources */,
+				DBA01B0E2071E6FF00083CD0 /* FuturePeek.swift in Sources */,
 				DB126D091E5368A100054E95 /* ExistentialFuture.swift in Sources */,
 				DB126D3F1E5368AD00054E95 /* ExistentialTask.swift in Sources */,
 				DB126D111E5368A100054E95 /* Protected.swift in Sources */,
@@ -894,6 +902,7 @@
 				DB126D301E5368A800054E95 /* TaskResult.swift in Sources */,
 				DB126D181E5368A200054E95 /* FutureEveryMap.swift in Sources */,
 				DBA01B0A2071E69100083CD0 /* FutureAndThen.swift in Sources */,
+				DBA01B0F2071E6FF00083CD0 /* FuturePeek.swift in Sources */,
 				DB126D141E5368A200054E95 /* ExistentialFuture.swift in Sources */,
 				DB126D4A1E5368AE00054E95 /* ExistentialTask.swift in Sources */,
 				DB126D1C1E5368A200054E95 /* Protected.swift in Sources */,
@@ -954,6 +963,7 @@
 				DB126D331E5368A900054E95 /* TaskResult.swift in Sources */,
 				DB126D231E5368A200054E95 /* FutureEveryMap.swift in Sources */,
 				DBA01B0B2071E69100083CD0 /* FutureAndThen.swift in Sources */,
+				DBA01B102071E6FF00083CD0 /* FuturePeek.swift in Sources */,
 				DB126D1F1E5368A200054E95 /* ExistentialFuture.swift in Sources */,
 				DB126D551E5368AE00054E95 /* ExistentialTask.swift in Sources */,
 				DB126D271E5368A200054E95 /* Protected.swift in Sources */,

--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -169,6 +169,10 @@
 		DB8A071C2060D38C00639AB3 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8A071B2060D38C00639AB3 /* PerformanceTests.swift */; };
 		DB8A071D2060D38C00639AB3 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8A071B2060D38C00639AB3 /* PerformanceTests.swift */; };
 		DB8A071E2060D38C00639AB3 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8A071B2060D38C00639AB3 /* PerformanceTests.swift */; };
+		DBA01AFE2071E5D300083CD0 /* FutureUpon.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01AFD2071E5D300083CD0 /* FutureUpon.swift */; };
+		DBA01AFF2071E5D300083CD0 /* FutureUpon.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01AFD2071E5D300083CD0 /* FutureUpon.swift */; };
+		DBA01B002071E5D300083CD0 /* FutureUpon.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01AFD2071E5D300083CD0 /* FutureUpon.swift */; };
+		DBA01B012071E5D300083CD0 /* FutureUpon.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA01AFD2071E5D300083CD0 /* FutureUpon.swift */; };
 		DBABD0BB203F2E3E00C50896 /* Atomics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBABD0BA203F2E3E00C50896 /* Atomics.swift */; };
 		DBABD0BC203F2E3E00C50896 /* Atomics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBABD0BA203F2E3E00C50896 /* Atomics.swift */; };
 		DBABD0BD203F2E3E00C50896 /* Atomics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBABD0BA203F2E3E00C50896 /* Atomics.swift */; };
@@ -257,6 +261,7 @@
 		DB55F1FD1D96968E00FC1439 /* TaskWorkItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskWorkItemTests.swift; sourceTree = "<group>"; };
 		DB55F20B1D969A1B00FC1439 /* FutureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureTests.swift; sourceTree = "<group>"; };
 		DB8A071B2060D38C00639AB3 /* PerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
+		DBA01AFD2071E5D300083CD0 /* FutureUpon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureUpon.swift; sourceTree = "<group>"; };
 		DBABD0BA203F2E3E00C50896 /* Atomics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomics.swift; sourceTree = "<group>"; };
 		DBC742631DC2F6D4002FB30D /* FutureEveryMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureEveryMap.swift; sourceTree = "<group>"; };
 		EBEB828C1DC4A79A00B7E089 /* TaskComprehensiveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskComprehensiveTests.swift; sourceTree = "<group>"; };
@@ -379,6 +384,7 @@
 				DB524C971D85200C00DDF16D /* FutureComposition.swift */,
 				DBC742631DC2F6D4002FB30D /* FutureEveryMap.swift */,
 				DB524C9B1D85200C00DDF16D /* FutureIgnore.swift */,
+				DBA01AFD2071E5D300083CD0 /* FutureUpon.swift */,
 				DB524C9F1D85200C00DDF16D /* Locking.swift */,
 				DB524C9E1D85200C00DDF16D /* Promise.swift */,
 				DB524C9C1D85200C00DDF16D /* Protected.swift */,
@@ -768,6 +774,7 @@
 				DB126D041E5368A100054E95 /* Locking.swift in Sources */,
 				DB126D361E5368AD00054E95 /* ResultPromise.swift in Sources */,
 				DB126D3B1E5368AD00054E95 /* TaskMap.swift in Sources */,
+				DBA01AFE2071E5D300083CD0 /* FutureUpon.swift in Sources */,
 				DB126D381E5368AD00054E95 /* TaskCollections.swift in Sources */,
 				DB126D3A1E5368AD00054E95 /* TaskIgnore.swift in Sources */,
 				DB126D391E5368AD00054E95 /* TaskGroup.swift in Sources */,
@@ -825,6 +832,7 @@
 				DB126D411E5368AD00054E95 /* ResultPromise.swift in Sources */,
 				DB126D461E5368AD00054E95 /* TaskMap.swift in Sources */,
 				DB126D431E5368AD00054E95 /* TaskCollections.swift in Sources */,
+				DBA01AFF2071E5D300083CD0 /* FutureUpon.swift in Sources */,
 				DB126D451E5368AD00054E95 /* TaskIgnore.swift in Sources */,
 				DB126D441E5368AD00054E95 /* TaskGroup.swift in Sources */,
 				DB126D071E5368A100054E95 /* Deferred.swift in Sources */,
@@ -882,6 +890,7 @@
 				DB126D4C1E5368AE00054E95 /* ResultPromise.swift in Sources */,
 				DB126D511E5368AE00054E95 /* TaskMap.swift in Sources */,
 				DB126D4E1E5368AE00054E95 /* TaskCollections.swift in Sources */,
+				DBA01B002071E5D300083CD0 /* FutureUpon.swift in Sources */,
 				DB126D501E5368AE00054E95 /* TaskIgnore.swift in Sources */,
 				DB126D4F1E5368AE00054E95 /* TaskGroup.swift in Sources */,
 				DB126D121E5368A200054E95 /* Deferred.swift in Sources */,
@@ -939,6 +948,7 @@
 				DB126D571E5368AE00054E95 /* ResultPromise.swift in Sources */,
 				DB126D5C1E5368AE00054E95 /* TaskMap.swift in Sources */,
 				DB126D591E5368AE00054E95 /* TaskCollections.swift in Sources */,
+				DBA01B012071E5D300083CD0 /* FutureUpon.swift in Sources */,
 				DB126D5B1E5368AE00054E95 /* TaskIgnore.swift in Sources */,
 				DB126D5A1E5368AE00054E95 /* TaskGroup.swift in Sources */,
 				DB126D1D1E5368A200054E95 /* Deferred.swift in Sources */,

--- a/Sources/Deferred/Deferred.swift
+++ b/Sources/Deferred/Deferred.swift
@@ -80,12 +80,6 @@ public final class Deferred<Value>: FutureProtocol, PromiseProtocol {
 
     // MARK: PromiseProtocol
 
-    public var isFilled: Bool {
-        return storage.withUnsafeMutablePointers { (_, pointerToReference) in
-            bnr_atomic_load_relaxed(pointerToReference) != nil
-        }
-    }
-
     @discardableResult
     public func fill(with value: Value) -> Bool {
         let reference = Storage.convertToReference(value)

--- a/Sources/Deferred/Executor.swift
+++ b/Sources/Deferred/Executor.swift
@@ -101,8 +101,6 @@ extension DispatchQueue: Executor {
     }
 }
 
-public typealias DefaultExecutor = DispatchQueue
-
 /// An operation queue manages a number of operation objects, making high
 /// level features like cancellation and dependencies simple.
 ///

--- a/Sources/Deferred/ExistentialFuture.swift
+++ b/Sources/Deferred/ExistentialFuture.swift
@@ -26,6 +26,10 @@ private class FutureBox<Value> {
         fatalError()
     }
 
+    func peek() -> Value? {
+        fatalError()
+    }
+
     func wait(until _: DispatchTime) -> Value? {
         fatalError()
     }
@@ -44,6 +48,10 @@ private final class ForwardedTo<Future: FutureProtocol>: FutureBox<Future.Value>
 
     override func upon(_ executor: Executor, execute body: @escaping(Future.Value) -> Void) {
         return base.upon(executor, execute: body)
+    }
+
+    override func peek() -> Future.Value? {
+        return base.peek()
     }
 
     override func wait(until time: DispatchTime) -> Future.Value? {
@@ -70,6 +78,10 @@ private final class Always<Value>: FutureBox<Value> {
         }
     }
 
+    override func peek() -> Value? {
+        return value
+    }
+
     override func wait(until _: DispatchTime) -> Value? {
         return value
     }
@@ -82,6 +94,10 @@ private final class Never<Value>: FutureBox<Value> {
     override func upon(_: DispatchQueue, execute _: @escaping(Value) -> Void) {}
 
     override func upon(_: Executor, execute _: @escaping(Value) -> Void) {}
+
+    override func peek() -> Value? {
+        return nil
+    }
 
     override func wait(until _: DispatchTime) -> Value? {
         return nil
@@ -134,6 +150,10 @@ public struct Future<Value>: FutureProtocol {
 
     public func upon(_ executor: Executor, execute body: @escaping(Value) -> Void) {
         return box.upon(executor, execute: body)
+    }
+
+    public func peek() -> Value? {
+        return box.peek()
     }
 
     public func wait(until time: DispatchTime) -> Value? {

--- a/Sources/Deferred/ExistentialFuture.swift
+++ b/Sources/Deferred/ExistentialFuture.swift
@@ -17,12 +17,12 @@ in a playground, the following post, and the Swift standard library:
 */
 
 // Abstract class that fake-conforms to `FutureProtocol` for use by `Future`.
-private class FutureBox<Value> {
-    func upon(_: Executor, execute _: @escaping(Value) -> Void) {
+private class Box<Value> {
+    func upon(_: Future<Value>.PreferredExecutor, execute _: @escaping(Value) -> Void) {
         fatalError()
     }
 
-    func upon(_: DispatchQueue, execute _: @escaping(Value) -> Void) {
+    func upon(_: Executor, execute _: @escaping(Value) -> Void) {
         fatalError()
     }
 
@@ -36,13 +36,13 @@ private class FutureBox<Value> {
 }
 
 // Concrete future wrapper given an instance of a `FutureProtocol`.
-private final class ForwardedTo<Future: FutureProtocol>: FutureBox<Future.Value> {
+private final class ForwardedTo<Future: FutureProtocol>: Box<Future.Value> {
     let base: Future
     init(base: Future) {
         self.base = base
     }
 
-    override func upon(_ executor: DispatchQueue, execute body: @escaping(Future.Value) -> Void) {
+    override func upon(_ executor: Future.PreferredExecutor, execute body: @escaping(Future.Value) -> Void) {
         return base.upon(executor, execute: body)
     }
 
@@ -60,13 +60,13 @@ private final class ForwardedTo<Future: FutureProtocol>: FutureBox<Future.Value>
 }
 
 // Concrete future wrapper for an always-filled future.
-private final class Always<Value>: FutureBox<Value> {
+private final class Always<Value>: Box<Value> {
     let value: Value
     init(value: Value) {
         self.value = value
     }
 
-    override func upon(_ queue: DispatchQueue, execute body: @escaping(Value) -> Void) {
+    override func upon(_ queue: Future<Value>.PreferredExecutor, execute body: @escaping(Value) -> Void) {
         queue.async { [value] in
             body(value)
         }
@@ -88,10 +88,10 @@ private final class Always<Value>: FutureBox<Value> {
 }
 
 // Concrete future wrapper that will never get filled.
-private final class Never<Value>: FutureBox<Value> {
+private final class Never<Value>: Box<Value> {
     override init() {}
 
-    override func upon(_: DispatchQueue, execute _: @escaping(Value) -> Void) {}
+    override func upon(_: Future<Value>.PreferredExecutor, execute _: @escaping(Value) -> Void) {}
 
     override func upon(_: Executor, execute _: @escaping(Value) -> Void) {}
 
@@ -117,7 +117,7 @@ private final class Never<Value>: FutureBox<Value> {
 ///   ensuring that only your implementation can fill the deferred value
 ///   using the `PromiseProtocol` aspect.
 public struct Future<Value>: FutureProtocol {
-    private let box: FutureBox<Value>
+    private let box: Box<Value>
 
     /// Create a future whose `upon(_:execute:)` methods forward to `base`.
     public init<OtherFuture: FutureProtocol>(_ base: OtherFuture)
@@ -144,7 +144,7 @@ public struct Future<Value>: FutureProtocol {
         self.box = other.box
     }
 
-    public func upon(_ queue: DispatchQueue, execute body: @escaping(Value) -> Void) {
+    public func upon(_ queue: PreferredExecutor, execute body: @escaping(Value) -> Void) {
         return box.upon(queue, execute: body)
     }
 

--- a/Sources/Deferred/Future.swift
+++ b/Sources/Deferred/Future.swift
@@ -8,10 +8,6 @@
 
 import Dispatch
 
-/// The natural executor for use with Futures; a policy of the framework to
-/// allow for shorthand syntax with `Future.upon(_:execute:)` and others.
-public typealias PreferredExecutor = DispatchQueue
-
 /// A future models reading a value which may become available at some point.
 ///
 /// A `FutureProtocol` may be preferable to an architecture using completion
@@ -92,16 +88,6 @@ public protocol FutureProtocol: CustomDebugStringConvertible, CustomReflectable 
     /// - parameter requestNextValue: Start a new operation with the future value.
     /// - returns: The new deferred value returned by the `transform`.
     func andThen<NewFuture: FutureProtocol>(upon executor: Executor, start requestNextValue: @escaping(Value) -> NewFuture) -> Future<NewFuture.Value>
-}
-
-extension FutureProtocol {
-    /// Call some `body` closure in the background once the value is determined.
-    ///
-    /// If the value is determined, the closure will be enqueued immediately,
-    /// but this call is always asynchronous.
-    public func upon(_ executor: PreferredExecutor = .any(), execute body: @escaping(Value) -> Void) {
-        upon(executor as Executor, execute: body)
-    }
 }
 
 extension FutureProtocol {

--- a/Sources/Deferred/Future.swift
+++ b/Sources/Deferred/Future.swift
@@ -148,33 +148,3 @@ extension FutureProtocol {
         return Mirror(self, children: CollectionOfOne(child), displayStyle: .optional, ancestorRepresentation: .suppressed)
     }
 }
-
-extension FutureProtocol {
-    public func map<NewValue>(upon executor: PreferredExecutor, transform: @escaping(Value) -> NewValue) -> Future<NewValue> {
-        return map(upon: executor as Executor, transform: transform)
-    }
-
-    public func map<NewValue>(upon executor: Executor, transform: @escaping(Value) -> NewValue) -> Future<NewValue> {
-        let deferred = Deferred<NewValue>()
-        upon(executor) {
-            deferred.fill(with: transform($0))
-        }
-        return Future(deferred)
-    }
-}
-
-extension FutureProtocol {
-    public func andThen<NewFuture: FutureProtocol>(upon executor: PreferredExecutor, start requestNextValue: @escaping(Value) -> NewFuture) -> Future<NewFuture.Value> {
-        return andThen(upon: executor as Executor, start: requestNextValue)
-    }
-
-    public func andThen<NewFuture: FutureProtocol>(upon executor: Executor, start requestNextValue: @escaping(Value) -> NewFuture) -> Future<NewFuture.Value> {
-        let deferred = Deferred<NewFuture.Value>()
-        upon(executor) {
-            requestNextValue($0).upon(executor) {
-                deferred.fill(with: $0)
-            }
-        }
-        return Future(deferred)
-    }
-}

--- a/Sources/Deferred/Future.swift
+++ b/Sources/Deferred/Future.swift
@@ -39,6 +39,14 @@ public protocol FutureProtocol: CustomDebugStringConvertible, CustomReflectable 
     /// `executor` immediately.
     func upon(_ executor: Executor, execute body: @escaping(Value) -> Void)
 
+    /// Checks for and returns a determined value.
+    ///
+    /// An implementation should use a "best effort" to return this value and
+    /// not unnecessarily block in order to to return.
+    ///
+    /// - returns: The determined value, if already filled, or `nil`.
+    func peek() -> Value?
+
     /// Waits synchronously for the value to become determined.
     ///
     /// If the value is already determined, the call returns immediately with
@@ -50,13 +58,6 @@ public protocol FutureProtocol: CustomDebugStringConvertible, CustomReflectable 
 }
 
 extension FutureProtocol {
-    /// Checks for and returns a determined value.
-    ///
-    /// - returns: The determined value, if already filled, or `nil`.
-    public func peek() -> Value? {
-        return wait(until: .now())
-    }
-
     /// Waits for the value to become determined, then returns it.
     ///
     /// This is equivalent to unwrapping the value of calling `wait(.Forever)`,

--- a/Sources/Deferred/Future.swift
+++ b/Sources/Deferred/Future.swift
@@ -57,26 +57,6 @@ public protocol FutureProtocol: CustomDebugStringConvertible, CustomReflectable 
     func wait(until time: DispatchTime) -> Value?
 }
 
-extension FutureProtocol {
-    /// Waits for the value to become determined, then returns it.
-    ///
-    /// This is equivalent to unwrapping the value of calling `wait(.Forever)`,
-    /// but may be more efficient.
-    ///
-    /// This getter will unnecessarily block execution. It might be useful for
-    /// testing, but otherwise it should be strictly avoided.
-    ///
-    /// - returns: The determined value.
-    var value: Value {
-        return wait(until: .distantFuture).unsafelyUnwrapped
-    }
-
-    /// Check whether or not the receiver is filled.
-    var isFilled: Bool {
-        return wait(until: .now()) != nil
-    }
-}
-
 // MARK: - Default implementations
 
 extension FutureProtocol {
@@ -85,11 +65,12 @@ extension FutureProtocol {
         var ret = ""
         ret.append(contentsOf: "\(Self.self)".prefix(while: { $0 != "<" }))
         ret.append("(")
-        if Value.self == Void.self, isFilled {
+        switch peek() {
+        case _? where Value.self == Void.self:
             ret.append("filled")
-        } else if let value = peek() {
+        case let value?:
             debugPrint(value, terminator: "", to: &ret)
-        } else {
+        case nil:
             ret.append("not filled")
         }
         ret.append(")")

--- a/Sources/Deferred/Future.swift
+++ b/Sources/Deferred/Future.swift
@@ -47,47 +47,6 @@ public protocol FutureProtocol: CustomDebugStringConvertible, CustomReflectable 
     /// - parameter time: A deadline for the value to be determined.
     /// - returns: The determined value, if filled within the timeout, or `nil`.
     func wait(until time: DispatchTime) -> Value?
-
-    /// Returns a future containing the result of mapping `transform` over the
-    /// deferred value.
-    func map<NewValue>(upon executor: PreferredExecutor, transform: @escaping(Value) -> NewValue) -> Future<NewValue>
-
-    /// Returns a future containing the result of mapping `transform` over the
-    /// deferred value.
-    ///
-    /// `map` submits the `transform` to the `executor` once the future's value
-    /// is determined.
-    ///
-    /// - parameter executor: Context to execute the transformation on.
-    /// - parameter transform: Creates something using the deferred value.
-    /// - returns: A new future that is filled once the receiver is determined.
-    func map<NewValue>(upon executor: Executor, transform: @escaping(Value) -> NewValue) -> Future<NewValue>
-
-    /// Begins another asynchronous operation by passing the deferred value to
-    /// `requestNextValue` once it becomes determined.
-    ///
-    /// `andThen` is similar to `map`, but `requestNextValue` returns another
-    /// future instead of an immediate value. Use `andThen` when you want
-    /// the reciever to feed into another asynchronous operation. You might hear
-    /// this referred to as "chaining" or "binding".
-    func andThen<NewFuture: FutureProtocol>(upon executor: PreferredExecutor, start requestNextValue: @escaping(Value) -> NewFuture) -> Future<NewFuture.Value>
-
-    /// Begins another asynchronous operation by passing the deferred value to
-    /// `requestNextValue` once it becomes determined.
-    ///
-    /// `andThen` is similar to `map`, but `requestNextValue` returns another
-    /// future instead of an immediate value. Use `andThen` when you want
-    /// the reciever to feed into another asynchronous operation. You might hear
-    /// this referred to as "chaining" or "binding".
-    ///
-    /// - note: It is important to keep in mind the thread safety of the
-    /// `requestNextValue` closure. Creating a new asynchronous task typically
-    /// involves state. Ensure the function is compatible with `executor`.
-    ///
-    /// - parameter executor: Context to execute the transformation on.
-    /// - parameter requestNextValue: Start a new operation with the future value.
-    /// - returns: The new deferred value returned by the `transform`.
-    func andThen<NewFuture: FutureProtocol>(upon executor: Executor, start requestNextValue: @escaping(Value) -> NewFuture) -> Future<NewFuture.Value>
 }
 
 extension FutureProtocol {

--- a/Sources/Deferred/FutureAndThen.swift
+++ b/Sources/Deferred/FutureAndThen.swift
@@ -1,0 +1,45 @@
+//
+//  FutureAndThen.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 4/2/16.
+//  Copyright © 2014-2016 Big Nerd Ranch. Licensed under MIT.
+//
+
+extension FutureProtocol {
+    /// Begins another asynchronous operation by passing the deferred value to
+    /// `requestNextValue` once it becomes determined.
+    ///
+    /// `andThen` is similar to `map`, but `requestNextValue` returns another
+    /// future instead of an immediate value. Use `andThen` when you want
+    /// the reciever to feed into another asynchronous operation. You might hear
+    /// this referred to as "chaining" or "binding".
+    public func andThen<NewFuture: FutureProtocol>(upon executor: PreferredExecutor, start requestNextValue: @escaping(Value) -> NewFuture) -> Future<NewFuture.Value> {
+        return andThen(upon: executor as Executor, start: requestNextValue)
+    }
+
+    /// Begins another asynchronous operation by passing the deferred value to
+    /// `requestNextValue` once it becomes determined.
+    ///
+    /// `andThen` is similar to `map`, but `requestNextValue` returns another
+    /// future instead of an immediate value. Use `andThen` when you want
+    /// the reciever to feed into another asynchronous operation. You might hear
+    /// this referred to as "chaining" or "binding".
+    ///
+    /// - note: It is important to keep in mind the thread safety of the
+    /// `requestNextValue` closure. Creating a new asynchronous task typically
+    /// involves state. Ensure the function is compatible with `executor`.
+    ///
+    /// - parameter executor: Context to execute the transformation on.
+    /// - parameter requestNextValue: Start a new operation with the future value.
+    /// - returns: The new deferred value returned by the `transform`.
+    public func andThen<NewFuture: FutureProtocol>(upon executor: Executor, start requestNextValue: @escaping(Value) -> NewFuture) -> Future<NewFuture.Value> {
+        let deferred = Deferred<NewFuture.Value>()
+        upon(executor) {
+            requestNextValue($0).upon(executor) {
+                deferred.fill(with: $0)
+            }
+        }
+        return Future(deferred)
+    }
+}

--- a/Sources/Deferred/FutureCollections.swift
+++ b/Sources/Deferred/FutureCollections.swift
@@ -37,7 +37,9 @@ private struct AllFilledFuture<Value>: FutureProtocol {
         }
 
         group.notify(queue: queue) { [combined] in
-            combined.fill(with: array.map { $0.value })
+            // Expect each to be filled right now.
+            // swiftlint:disable:next force_unwrapping
+            combined.fill(with: array.map({ $0.peek()! }))
         }
     }
 

--- a/Sources/Deferred/FutureEveryMap.swift
+++ b/Sources/Deferred/FutureEveryMap.swift
@@ -25,6 +25,10 @@ private struct LazyMapFuture<Base: FutureProtocol, NewValue>: FutureProtocol {
         }
     }
 
+    func peek() -> NewValue? {
+        return base.peek().map(transform)
+    }
+
     func wait(until time: DispatchTime) -> NewValue? {
         return base.wait(until: time).map(transform)
     }

--- a/Sources/Deferred/FutureMap.swift
+++ b/Sources/Deferred/FutureMap.swift
@@ -1,0 +1,32 @@
+//
+//  FutureMap.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 4/2/16.
+//  Copyright © 2014-2016 Big Nerd Ranch. Licensed under MIT.
+//
+
+extension FutureProtocol {
+    /// Returns a future containing the result of mapping `transform` over the
+    /// deferred value.
+    public func map<NewValue>(upon executor: PreferredExecutor, transform: @escaping(Value) -> NewValue) -> Future<NewValue> {
+        return map(upon: executor as Executor, transform: transform)
+    }
+
+    /// Returns a future containing the result of mapping `transform` over the
+    /// deferred value.
+    ///
+    /// `map` submits the `transform` to the `executor` once the future's value
+    /// is determined.
+    ///
+    /// - parameter executor: Context to execute the transformation on.
+    /// - parameter transform: Creates something using the deferred value.
+    /// - returns: A new future that is filled once the receiver is determined.
+    public func map<NewValue>(upon executor: Executor, transform: @escaping(Value) -> NewValue) -> Future<NewValue> {
+        let deferred = Deferred<NewValue>()
+        upon(executor) {
+            deferred.fill(with: transform($0))
+        }
+        return Future(deferred)
+    }
+}

--- a/Sources/Deferred/FuturePeek.swift
+++ b/Sources/Deferred/FuturePeek.swift
@@ -1,0 +1,21 @@
+//
+//  FuturePeek.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 11/6/15.
+//  Copyright © 2015-2018 Big Nerd Ranch. Licensed under MIT.
+//
+
+extension FutureProtocol {
+    /// By default, calls `wait` with no delay.
+    public func peek() -> Value? {
+        return wait(until: .now())
+    }
+}
+
+extension PromiseProtocol where Self: FutureProtocol {
+    /// By default, checks for a fulfilled future value.
+    public var isFilled: Bool {
+        return peek() != nil
+    }
+}

--- a/Sources/Deferred/FutureUpon.swift
+++ b/Sources/Deferred/FutureUpon.swift
@@ -1,0 +1,32 @@
+//
+//  FutureUpon.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 4/2/16.
+//  Copyright © 2014-2018 Big Nerd Ranch. Licensed under MIT.
+//
+
+import Dispatch
+
+extension FutureProtocol {
+    /// The natural executor for use with futures; a policy of the framework to
+    /// allow for shorthand syntax with `Future.upon(_:execute:)` and others.
+    public typealias PreferredExecutor = DispatchQueue
+
+    /// The executor to use as a default argument to `upon` methods on `Future`.
+    ///
+    /// Don't provide a default parameter using this declaration unless doing
+    /// so is unambiguous. For instance, `map` and `andThen` once had a default
+    /// executor, but users found it unclear wherethe  handlers executed.
+    public static var defaultUponExecutor: PreferredExecutor {
+        return DispatchQueue.any()
+    }
+
+    /// Call some `body` closure in the background once the value is determined.
+    ///
+    /// If the value is determined, the closure will be enqueued immediately,
+    /// but this call is always asynchronous.
+    public func upon(_ executor: PreferredExecutor = Self.defaultUponExecutor, execute body: @escaping(Value) -> Void) {
+        upon(executor as Executor, execute: body)
+    }
+}

--- a/Sources/Task/ExistentialTask.swift
+++ b/Sources/Task/ExistentialTask.swift
@@ -101,6 +101,10 @@ extension Task: FutureProtocol {
         future.upon(executor, execute: body)
     }
 
+    public func peek() -> Result? {
+        return future.peek()
+    }
+
     public func wait(until timeout: DispatchTime) -> Result? {
         return future.wait(until: timeout)
     }

--- a/Sources/Task/ResultFuture.swift
+++ b/Sources/Task/ResultFuture.swift
@@ -48,7 +48,7 @@ extension FutureProtocol where Value: Either {
     ///
     /// - see: uponSuccess(on:execute:)
     /// - see: upon(_:execute:)
-    public func uponSuccess(on executor: PreferredExecutor = .any(), execute body: @escaping(Value.Right) -> Void) {
+    public func uponSuccess(on executor: PreferredExecutor = Self.defaultUponExecutor, execute body: @escaping(Value.Right) -> Void) {
         upon(executor, execute: commonSuccessBody(body))
     }
 
@@ -56,7 +56,7 @@ extension FutureProtocol where Value: Either {
     ///
     /// - see: uponFailure(on:execute:)
     /// - see: upon(_:body:)
-    public func uponFailure(on executor: PreferredExecutor = .any(), execute body: @escaping(Value.Left) -> Void) {
+    public func uponFailure(on executor: PreferredExecutor = Self.defaultUponExecutor, execute body: @escaping(Value.Left) -> Void) {
         upon(executor, execute: commonFailureBody(body))
     }
 }

--- a/Tests/AllTestsCommon.swift
+++ b/Tests/AllTestsCommon.swift
@@ -47,6 +47,24 @@ extension XCTestCase {
 }
 
 extension FutureProtocol {
+    /// Waits for the value to become determined, then returns it.
+    ///
+    /// This is equivalent to unwrapping the value of calling
+    /// `wait(until: .distantFuture)`, but may be more efficient.
+    ///
+    /// This getter will unnecessarily block execution. It might be useful for
+    /// testing, but otherwise it should be strictly avoided.
+    ///
+    /// - returns: The determined value.
+    var value: Value {
+        return wait(until: .distantFuture).unsafelyUnwrapped
+    }
+
+    /// Check whether or not the receiver is filled.
+    var isFilled: Bool {
+        return peek() != nil
+    }
+
     func shortWait() -> Value? {
         return wait(until: .now() + 0.05)
     }

--- a/Tests/DeferredTests/DeferredTests.swift
+++ b/Tests/DeferredTests/DeferredTests.swift
@@ -17,8 +17,9 @@ import Foundation
 
 class DeferredTests: XCTestCase {
     static let universalTests: [(String, (DeferredTests) -> () throws -> Void)] = [
+        ("testPeekWhenUnfilled", testPeekWhenUnfilled),
+        ("testPeekWhenFilled", testPeekWhenFilled),
         ("testWaitWithTimeout", testWaitWithTimeout),
-        ("testPeek", testPeek),
         ("testValueOnFilled", testValueOnFilled),
         ("testValueBlocksWhileUnfilled", testValueBlocksWhileUnfilled),
         ("testValueUnblocksWhenUnfilledIsFilled", testValueUnblocksWhenUnfilledIsFilled),
@@ -55,6 +56,16 @@ class DeferredTests: XCTestCase {
         #endif
     }
 
+    func testPeekWhenUnfilled() {
+        let unfilled = Deferred<Int>()
+        XCTAssertNil(unfilled.peek())
+    }
+
+    func testPeekWhenFilled() {
+        let filled = Deferred(filledWith: 1)
+        XCTAssertEqual(filled.peek(), 1)
+    }
+
     func testWaitWithTimeout() {
         let deferred = Deferred<Int>()
 
@@ -67,13 +78,6 @@ class DeferredTests: XCTestCase {
         XCTAssertNil(deferred.shortWait())
 
         shortWait(for: [ expect ])
-    }
-
-    func testPeek() {
-        let unfilled = Deferred<Int>()
-        let filled = Deferred(filledWith: 1)
-        XCTAssertNil(unfilled.peek())
-        XCTAssertEqual(filled.peek(), 1)
     }
 
     func testValueOnFilled() {

--- a/Tests/DeferredTests/ExistentialFutureTests.swift
+++ b/Tests/DeferredTests/ExistentialFutureTests.swift
@@ -12,7 +12,8 @@ import XCTest
 
 class ExistentialFutureTests: XCTestCase {
     static let allTests: [(String, (ExistentialFutureTests) -> () throws -> Void)] = [
-        ("testFilledAnyFutureWaitAlwaysReturns", testFilledAnyFutureWaitAlwaysReturns),
+        ("testPeekWhenFilled", testPeekWhenFilled),
+        ("testPeekWhenUnfilled", testPeekWhenUnfilled),
         ("testAnyWaitWithTimeout", testAnyWaitWithTimeout),
         ("testFilledAnyFutureUpon", testFilledAnyFutureUpon),
         ("testUnfilledAnyUponCalledWhenFilled", testUnfilledAnyUponCalledWhenFilled),
@@ -33,10 +34,16 @@ class ExistentialFutureTests: XCTestCase {
         super.tearDown()
     }
 
-    func testFilledAnyFutureWaitAlwaysReturns() {
+    func testPeekWhenFilled() {
         anyFuture = Future(value: 42)
-        let peek = anyFuture.wait(until: .distantFuture)
+        let peek = anyFuture.peek()
         XCTAssertNotNil(peek)
+    }
+
+    func testPeekWhenUnfilled() {
+        anyFuture = Future<Int>()
+        let peek = anyFuture.peek()
+        XCTAssertNil(peek)
     }
 
     func testAnyWaitWithTimeout() {


### PR DESCRIPTION
#### What's in this pull request?

Moves default implementations out from the `FutureProtocol` definition. Adds `peek()` as a requirement, removes `map` and `andThen` as requirements.

#### Testing

No notable changes.

##### TODO

- [x] Does `Future` need extra `peek` calls or are they already covered?

#### API Changes

Many breaking changes to `FutureProtocol`, few likely to be source-breaking.