### PR TITLE
Skinny Deferred

### DIFF
--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -172,6 +172,10 @@
 		DB34FC942096DCE1005D5B82 /* FilledDeferredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB34FC932096DCE1005D5B82 /* FilledDeferredTests.swift */; };
 		DB34FC952096DCE1005D5B82 /* FilledDeferredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB34FC932096DCE1005D5B82 /* FilledDeferredTests.swift */; };
 		DB34FC962096DCE1005D5B82 /* FilledDeferredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB34FC932096DCE1005D5B82 /* FilledDeferredTests.swift */; };
+		DB3E3C4620964B2A001F648A /* DeferredVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3E3C4520964B2A001F648A /* DeferredVariant.swift */; };
+		DB3E3C4720964B2A001F648A /* DeferredVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3E3C4520964B2A001F648A /* DeferredVariant.swift */; };
+		DB3E3C4820964B2A001F648A /* DeferredVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3E3C4520964B2A001F648A /* DeferredVariant.swift */; };
+		DB3E3C4920964B2A001F648A /* DeferredVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3E3C4520964B2A001F648A /* DeferredVariant.swift */; };
 		DB8A071C2060D38C00639AB3 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8A071B2060D38C00639AB3 /* PerformanceTests.swift */; };
 		DB8A071D2060D38C00639AB3 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8A071B2060D38C00639AB3 /* PerformanceTests.swift */; };
 		DB8A071E2060D38C00639AB3 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8A071B2060D38C00639AB3 /* PerformanceTests.swift */; };
@@ -232,6 +236,7 @@
 		DB34FC8F2096D335005D5B82 /* ObjectDeferredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectDeferredTests.swift; sourceTree = "<group>"; };
 		DB34FC932096DCE1005D5B82 /* FilledDeferredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilledDeferredTests.swift; sourceTree = "<group>"; };
 		DB39B2D01DDE194C00DDE4C0 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		DB3E3C4520964B2A001F648A /* DeferredVariant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredVariant.swift; sourceTree = "<group>"; };
 		DB4002691DDC21B300382BAE /* SwiftBugTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftBugTests.swift; sourceTree = "<group>"; };
 		DB524C8C1D851E5B00DDF16D /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		DB524C8D1D851E5B00DDF16D /* Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Framework.xcconfig; sourceTree = "<group>"; };
@@ -400,6 +405,7 @@
 			children = (
 				DBABD0BA203F2E3E00C50896 /* Atomics.swift */,
 				DB524C931D85200C00DDF16D /* Deferred.swift */,
+				DB3E3C4520964B2A001F648A /* DeferredVariant.swift */,
 				DB524C941D85200C00DDF16D /* Executor.swift */,
 				DB524C951D85200C00DDF16D /* ExistentialFuture.swift */,
 				DB524C9A1D85200C00DDF16D /* Future.swift */,
@@ -800,6 +806,7 @@
 				DB126D291E5368A700054E95 /* EitherRecovery.swift in Sources */,
 				DB126CFF1E5368A100054E95 /* Future.swift in Sources */,
 				DB126D3E1E5368AD00054E95 /* TaskWorkItem.swift in Sources */,
+				DB3E3C4620964B2A001F648A /* DeferredVariant.swift in Sources */,
 				DB126D031E5368A100054E95 /* FutureIgnore.swift in Sources */,
 				DB126D041E5368A100054E95 /* Locking.swift in Sources */,
 				DB126D361E5368AD00054E95 /* ResultPromise.swift in Sources */,
@@ -863,6 +870,7 @@
 				DB126D0A1E5368A100054E95 /* Future.swift in Sources */,
 				DB126D491E5368AD00054E95 /* TaskWorkItem.swift in Sources */,
 				DB126D0E1E5368A100054E95 /* FutureIgnore.swift in Sources */,
+				DB3E3C4720964B2A001F648A /* DeferredVariant.swift in Sources */,
 				DB126D0F1E5368A100054E95 /* Locking.swift in Sources */,
 				DB126D411E5368AD00054E95 /* ResultPromise.swift in Sources */,
 				DB126D461E5368AD00054E95 /* TaskMap.swift in Sources */,
@@ -926,6 +934,7 @@
 				DB126D151E5368A200054E95 /* Future.swift in Sources */,
 				DB126D541E5368AE00054E95 /* TaskWorkItem.swift in Sources */,
 				DB126D191E5368A200054E95 /* FutureIgnore.swift in Sources */,
+				DB3E3C4820964B2A001F648A /* DeferredVariant.swift in Sources */,
 				DB126D1A1E5368A200054E95 /* Locking.swift in Sources */,
 				DB126D4C1E5368AE00054E95 /* ResultPromise.swift in Sources */,
 				DB126D511E5368AE00054E95 /* TaskMap.swift in Sources */,
@@ -989,6 +998,7 @@
 				DB126D201E5368A200054E95 /* Future.swift in Sources */,
 				DB126D5F1E5368AE00054E95 /* TaskWorkItem.swift in Sources */,
 				DB126D241E5368A200054E95 /* FutureIgnore.swift in Sources */,
+				DB3E3C4920964B2A001F648A /* DeferredVariant.swift in Sources */,
 				DB126D251E5368A200054E95 /* Locking.swift in Sources */,
 				DB126D571E5368AE00054E95 /* ResultPromise.swift in Sources */,
 				DB126D5C1E5368AE00054E95 /* TaskMap.swift in Sources */,

--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -176,6 +176,10 @@
 		DB3E3C4720964B2A001F648A /* DeferredVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3E3C4520964B2A001F648A /* DeferredVariant.swift */; };
 		DB3E3C4820964B2A001F648A /* DeferredVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3E3C4520964B2A001F648A /* DeferredVariant.swift */; };
 		DB3E3C4920964B2A001F648A /* DeferredVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3E3C4520964B2A001F648A /* DeferredVariant.swift */; };
+		DB647573209652DC00F67EA1 /* DeferredQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB647572209652DC00F67EA1 /* DeferredQueue.swift */; };
+		DB647574209652DC00F67EA1 /* DeferredQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB647572209652DC00F67EA1 /* DeferredQueue.swift */; };
+		DB647575209652DC00F67EA1 /* DeferredQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB647572209652DC00F67EA1 /* DeferredQueue.swift */; };
+		DB647576209652DC00F67EA1 /* DeferredQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB647572209652DC00F67EA1 /* DeferredQueue.swift */; };
 		DB8A071C2060D38C00639AB3 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8A071B2060D38C00639AB3 /* PerformanceTests.swift */; };
 		DB8A071D2060D38C00639AB3 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8A071B2060D38C00639AB3 /* PerformanceTests.swift */; };
 		DB8A071E2060D38C00639AB3 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8A071B2060D38C00639AB3 /* PerformanceTests.swift */; };
@@ -285,6 +289,7 @@
 		DB55F1FC1D96968E00FC1439 /* TaskTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskTests.swift; sourceTree = "<group>"; };
 		DB55F1FD1D96968E00FC1439 /* TaskWorkItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskWorkItemTests.swift; sourceTree = "<group>"; };
 		DB55F20B1D969A1B00FC1439 /* FutureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureTests.swift; sourceTree = "<group>"; };
+		DB647572209652DC00F67EA1 /* DeferredQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredQueue.swift; sourceTree = "<group>"; };
 		DB8A071B2060D38C00639AB3 /* PerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		DBA01AFD2071E5D300083CD0 /* FutureUpon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureUpon.swift; sourceTree = "<group>"; };
 		DBA01B022071E68F00083CD0 /* FutureMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureMap.swift; sourceTree = "<group>"; };
@@ -405,6 +410,7 @@
 			children = (
 				DBABD0BA203F2E3E00C50896 /* Atomics.swift */,
 				DB524C931D85200C00DDF16D /* Deferred.swift */,
+				DB647572209652DC00F67EA1 /* DeferredQueue.swift */,
 				DB3E3C4520964B2A001F648A /* DeferredVariant.swift */,
 				DB524C941D85200C00DDF16D /* Executor.swift */,
 				DB524C951D85200C00DDF16D /* ExistentialFuture.swift */,
@@ -817,6 +823,7 @@
 				DB126D391E5368AD00054E95 /* TaskGroup.swift in Sources */,
 				DB126CFC1E5368A100054E95 /* Deferred.swift in Sources */,
 				DB126D051E5368A100054E95 /* Promise.swift in Sources */,
+				DB647573209652DC00F67EA1 /* DeferredQueue.swift in Sources */,
 				DBA01B042071E69100083CD0 /* FutureMap.swift in Sources */,
 				DB126D001E5368A100054E95 /* FutureCollections.swift in Sources */,
 				DB126D011E5368A100054E95 /* FutureComposition.swift in Sources */,
@@ -881,6 +888,7 @@
 				DB126D071E5368A100054E95 /* Deferred.swift in Sources */,
 				DBABD0BC203F2E3E00C50896 /* Atomics.swift in Sources */,
 				DB126D101E5368A100054E95 /* Promise.swift in Sources */,
+				DB647574209652DC00F67EA1 /* DeferredQueue.swift in Sources */,
 				DBA01B052071E69100083CD0 /* FutureMap.swift in Sources */,
 				DB126D0B1E5368A100054E95 /* FutureCollections.swift in Sources */,
 				DB126D0C1E5368A100054E95 /* FutureComposition.swift in Sources */,
@@ -945,6 +953,7 @@
 				DB126D121E5368A200054E95 /* Deferred.swift in Sources */,
 				DBABD0BD203F2E3E00C50896 /* Atomics.swift in Sources */,
 				DB126D1B1E5368A200054E95 /* Promise.swift in Sources */,
+				DB647575209652DC00F67EA1 /* DeferredQueue.swift in Sources */,
 				DBA01B062071E69100083CD0 /* FutureMap.swift in Sources */,
 				DB126D161E5368A200054E95 /* FutureCollections.swift in Sources */,
 				DB126D171E5368A200054E95 /* FutureComposition.swift in Sources */,
@@ -1009,6 +1018,7 @@
 				DB126D1D1E5368A200054E95 /* Deferred.swift in Sources */,
 				DBABD0BE203F2E3E00C50896 /* Atomics.swift in Sources */,
 				DB126D261E5368A200054E95 /* Promise.swift in Sources */,
+				DB647576209652DC00F67EA1 /* DeferredQueue.swift in Sources */,
 				DBA01B072071E69100083CD0 /* FutureMap.swift in Sources */,
 				DB126D211E5368A200054E95 /* FutureCollections.swift in Sources */,
 				DB126D221E5368A200054E95 /* FutureComposition.swift in Sources */,

--- a/Sources/Atomics/include/Atomics.h
+++ b/Sources/Atomics/include/Atomics.h
@@ -24,6 +24,10 @@
 #ifndef __BNR_DEFERRED_ATOMIC_SHIMS__
 #define __BNR_DEFERRED_ATOMIC_SHIMS__
 
+#if !__has_include(<stdatomic.h>) || !__has_extension(c_atomic)
+#error Required compiler features are not available
+#endif
+
 #include <stdatomic.h>
 #if defined(__APPLE__)
 #include <os/lock.h>
@@ -31,11 +35,9 @@
 #include <pthread.h>
 #include <dispatch/dispatch.h>
 
-#if defined(__has_attribute) && __has_attribute(always_inline)
 #define BNR_ATOMIC_INLINE static inline __attribute__((always_inline))
-#else
-#define BNR_ATOMIC_INLINE static inline
-#endif
+#define BNR_ATOMIC_OVERLOAD __attribute__((overloadable))
+#define BNR_ATOMIC_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 
 #if !defined(SWIFT_ENUM)
 #define SWIFT_ENUM(_type, _name) enum _name _name##_t; enum _name
@@ -106,7 +108,8 @@ bool bnr_native_lock_trylock(bnr_native_lock_t address) {
     return pthread_mutex_trylock(&address->impl.legacy) == 0;
 }
 
-BNR_ATOMIC_INLINE void bnr_native_lock_unlock(bnr_native_lock_t address) {
+BNR_ATOMIC_INLINE
+void bnr_native_lock_unlock(bnr_native_lock_t address) {
 #if defined(__APPLE__)
     if (&os_unfair_lock_unlock != NULL) {
         return os_unfair_lock_unlock(&address->impl.modern);
@@ -116,80 +119,87 @@ BNR_ATOMIC_INLINE void bnr_native_lock_unlock(bnr_native_lock_t address) {
     pthread_mutex_unlock(&address->impl.legacy);
 }
 
-typedef volatile struct bnr_atomic_ptr_s {
-    _Atomic(const void *_Nullable) value;
-} bnr_atomic_ptr, *_Nonnull bnr_atomic_ptr_t;
+typedef const void *_Nullable volatile *_Nonnull bnr_atomic_ptr_t;
 
-BNR_ATOMIC_INLINE
-const void *_Nullable bnr_atomic_ptr_load(bnr_atomic_ptr_t target, bnr_atomic_memory_order_t order) {
-    return atomic_load_explicit(&target->value, order);
+BNR_ATOMIC_INLINE BNR_ATOMIC_OVERLOAD
+void bnr_atomic_init(bnr_atomic_ptr_t target, const void *_Nullable initial) {
+    atomic_init((const void *_Atomic *)target, initial);
 }
 
-BNR_ATOMIC_INLINE
-const void *_Nullable bnr_atomic_ptr_exchange(bnr_atomic_ptr_t target, const void *_Nullable desired, bnr_atomic_memory_order_t order) {
-    return atomic_exchange_explicit(&target->value, desired, order);
+BNR_ATOMIC_INLINE BNR_ATOMIC_WARN_UNUSED_RESULT BNR_ATOMIC_OVERLOAD
+const void *_Nullable bnr_atomic_load(bnr_atomic_ptr_t target, bnr_atomic_memory_order_t order) {
+    return atomic_load_explicit((const void *_Atomic *)target, order);
 }
 
-BNR_ATOMIC_INLINE
-bool bnr_atomic_ptr_compare_and_swap(bnr_atomic_ptr_t target, const void *_Nullable expected, const void *_Nullable desired, bnr_atomic_memory_order_t order) {
-    return atomic_compare_exchange_strong_explicit(&target->value, &expected, desired, order, memory_order_relaxed);
+BNR_ATOMIC_INLINE BNR_ATOMIC_WARN_UNUSED_RESULT
+const void *_Nullable bnr_atomic_exchange(bnr_atomic_ptr_t target, const void *_Nullable desired, bnr_atomic_memory_order_t order) {
+    return atomic_exchange_explicit((const void *_Atomic *)target, desired, order);
 }
 
-typedef volatile struct bnr_atomic_flag_s {
-    _Atomic(_Bool) value;
-} bnr_atomic_flag, *_Nonnull bnr_atomic_flag_t;
-
-BNR_ATOMIC_INLINE
-bool bnr_atomic_flag_load(bnr_atomic_flag_t target, bnr_atomic_memory_order_t order) {
-    return atomic_load_explicit(&target->value, order);
+BNR_ATOMIC_INLINE BNR_ATOMIC_WARN_UNUSED_RESULT
+bool bnr_atomic_compare_and_swap(bnr_atomic_ptr_t target, const void *_Nullable expected, const void *_Nullable desired, bnr_atomic_memory_order_t order) {
+    return atomic_compare_exchange_strong_explicit((const void *_Atomic *)target, &expected, desired, order, memory_order_relaxed);
 }
 
-BNR_ATOMIC_INLINE
-bool bnr_atomic_flag_test_and_set(bnr_atomic_flag_t target, bnr_atomic_memory_order_t order) {
-    return atomic_exchange_explicit(&target->value, true, order);
+typedef volatile bool *_Nonnull bnr_atomic_flag_t;
+
+BNR_ATOMIC_INLINE BNR_ATOMIC_OVERLOAD
+void bnr_atomic_init(bnr_atomic_flag_t target, bool initial) {
+    atomic_init((atomic_bool *)target, initial);
 }
 
-typedef volatile struct bnr_atomic_bitmask_s {
-    _Atomic(uint8_t) value;
-} bnr_atomic_bitmask, *_Nonnull bnr_atomic_bitmask_t;
-
-BNR_ATOMIC_INLINE
-void bnr_atomic_bitmask_init(bnr_atomic_bitmask_t target, uint8_t mask) {
-    atomic_init(&target->value, mask);
+BNR_ATOMIC_INLINE BNR_ATOMIC_WARN_UNUSED_RESULT BNR_ATOMIC_OVERLOAD
+bool bnr_atomic_load(bnr_atomic_flag_t target, bnr_atomic_memory_order_t order) {
+    return atomic_load_explicit((atomic_bool *)target, order);
 }
 
-BNR_ATOMIC_INLINE
-uint8_t bnr_atomic_bitmask_add(bnr_atomic_bitmask_t target, uint8_t mask, bnr_atomic_memory_order_t order) {
-    return atomic_fetch_or_explicit(&target->value, mask, order);
+BNR_ATOMIC_INLINE BNR_ATOMIC_OVERLOAD
+void bnr_atomic_store(bnr_atomic_flag_t target, bool desired, bnr_atomic_memory_order_t order) {
+    atomic_store_explicit((atomic_bool *)target, desired, order);
 }
 
-BNR_ATOMIC_INLINE
-uint8_t bnr_atomic_bitmask_remove(bnr_atomic_bitmask_t target, uint8_t mask, bnr_atomic_memory_order_t order) {
-    return atomic_fetch_and_explicit(&target->value, ~mask, order);
+typedef volatile uint8_t *_Nonnull bnr_atomic_bitmask_t;
+
+BNR_ATOMIC_INLINE BNR_ATOMIC_OVERLOAD
+void bnr_atomic_init(bnr_atomic_bitmask_t target, uint8_t mask) {
+    atomic_init((uint8_t _Atomic *)target, mask);
 }
 
-BNR_ATOMIC_INLINE
-bool bnr_atomic_bitmask_test(bnr_atomic_bitmask_t target, uint8_t mask, bnr_atomic_memory_order_t order) {
-    return (atomic_load_explicit(&target->value, order) & mask) != 0;
+BNR_ATOMIC_INLINE BNR_ATOMIC_WARN_UNUSED_RESULT BNR_ATOMIC_OVERLOAD
+uint8_t bnr_atomic_load(bnr_atomic_bitmask_t target, bnr_atomic_memory_order_t order) {
+    return atomic_load_explicit((uint8_t _Atomic *)target, order);
 }
 
-typedef volatile struct bnr_atomic_counter_s {
-    _Atomic(long) value;
-} bnr_atomic_counter, *_Nonnull bnr_atomic_counter_t;
-
-BNR_ATOMIC_INLINE
-long bnr_atomic_counter_load(bnr_atomic_counter_t target) {
-    return atomic_load(&target->value);
+BNR_ATOMIC_INLINE BNR_ATOMIC_OVERLOAD
+uint8_t bnr_atomic_fetch_or(bnr_atomic_bitmask_t target, uint8_t mask, bnr_atomic_memory_order_t order) {
+    return atomic_fetch_or_explicit((uint8_t _Atomic *)target, mask, order);
 }
 
-BNR_ATOMIC_INLINE
-long bnr_atomic_counter_increment(bnr_atomic_counter_t target) {
-    return atomic_fetch_add(&target->value, 1) + 1;
+BNR_ATOMIC_INLINE BNR_ATOMIC_OVERLOAD
+uint8_t bnr_atomic_fetch_and(bnr_atomic_bitmask_t target, uint8_t mask, bnr_atomic_memory_order_t order) {
+    return atomic_fetch_and_explicit((uint8_t _Atomic *)target, mask, order);
 }
 
-BNR_ATOMIC_INLINE
-long bnr_atomic_counter_decrement(bnr_atomic_counter_t target) {
-    return atomic_fetch_sub(&target->value, 1) - 1;
+typedef volatile long *_Nonnull bnr_atomic_counter_t;
+
+BNR_ATOMIC_INLINE BNR_ATOMIC_OVERLOAD
+void bnr_atomic_init(bnr_atomic_counter_t target) {
+    atomic_init((atomic_long *)target, 0);
+}
+
+BNR_ATOMIC_INLINE BNR_ATOMIC_WARN_UNUSED_RESULT BNR_ATOMIC_OVERLOAD
+long bnr_atomic_load(bnr_atomic_counter_t target) {
+    return atomic_load((atomic_long *)target);
+}
+
+BNR_ATOMIC_INLINE BNR_ATOMIC_OVERLOAD
+long bnr_atomic_fetch_add(bnr_atomic_counter_t target, long offset) {
+    return atomic_fetch_add((atomic_long *)target, offset);
+}
+
+BNR_ATOMIC_INLINE BNR_ATOMIC_OVERLOAD
+long bnr_atomic_fetch_subtract(bnr_atomic_counter_t target, long offset) {
+    return atomic_fetch_sub((atomic_long *)target, offset);
 }
 
 #undef SWIFT_ENUM

--- a/Sources/Atomics/include/Atomics.h
+++ b/Sources/Atomics/include/Atomics.h
@@ -38,6 +38,7 @@
 #define BNR_ATOMIC_INLINE static inline __attribute__((always_inline))
 #define BNR_ATOMIC_OVERLOAD __attribute__((overloadable))
 #define BNR_ATOMIC_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#define BNR_ATOMIC_LIKELY(expression) __builtin_expect(!!(expression), 1)
 
 #if !defined(SWIFT_ENUM)
 #define SWIFT_ENUM(_type, _name) enum _name _name##_t; enum _name
@@ -139,6 +140,22 @@ const void *_Nullable bnr_atomic_exchange(bnr_atomic_ptr_t target, const void *_
 BNR_ATOMIC_INLINE BNR_ATOMIC_WARN_UNUSED_RESULT
 bool bnr_atomic_compare_and_swap(bnr_atomic_ptr_t target, const void *_Nullable expected, const void *_Nullable desired, bnr_atomic_memory_order_t order) {
     return atomic_compare_exchange_strong_explicit((const void *_Atomic *)target, &expected, desired, order, memory_order_relaxed);
+}
+
+BNR_ATOMIC_INLINE BNR_ATOMIC_WARN_UNUSED_RESULT
+const void *_Nonnull bnr_atomic_load_and_wait(bnr_atomic_ptr_t target) {
+    const void *result = NULL;
+    for (;;) {
+        if (BNR_ATOMIC_LIKELY(result = bnr_atomic_load(target, bnr_atomic_memory_order_acquire))) break;
+#if defined(__x86_64__) || defined(__i386__)
+        __asm__("pause");
+#elif defined(__arm__) || defined(__arm64__)
+        __asm__("yield");
+#else
+        __asm__("");
+#endif
+    }
+    return result;
 }
 
 typedef volatile bool *_Nonnull bnr_atomic_flag_t;

--- a/Sources/Deferred/Atomics.swift
+++ b/Sources/Deferred/Atomics.swift
@@ -154,3 +154,11 @@ func bnr_atomic_initialize_once<T: AnyObject>(_ target: UnsafeMutablePointer<T?>
     }
     return wonRace
 }
+
+@discardableResult
+func bnr_atomic_initialize_once(_ target: UnsafeMutablePointer<Bool>, _ handler: () -> Void) -> Bool {
+    guard !bnr_atomic_load(target, .acquire) else { return false }
+    handler()
+    bnr_atomic_store(target, true, .release)
+    return true
+}

--- a/Sources/Deferred/Deferred.swift
+++ b/Sources/Deferred/Deferred.swift
@@ -8,8 +8,17 @@
 
 import Dispatch
 
-/// A deferred is a value that may become determined (or "filled") at some point
-/// in the future. Once a deferred value is determined, it cannot change.
+/// A value that may become determined (or "filled") at some point in the
+/// future. Once determined, it cannot change.
+///
+/// You may subscribe to be notified once the value becomes determined.
+///
+/// Handlers and their captures are strongly referenced until:
+/// - they are executed when the value is determined
+/// - the last copy to this type escapes without the value becoming determined
+///
+/// If the value never becomes determined, a handler submitted to it will never
+/// be executed.
 public struct Deferred<Value> {
     /// The primary storage, initialized with a value once-and-only-once (at
     /// init or later).

--- a/Sources/Deferred/Deferred.swift
+++ b/Sources/Deferred/Deferred.swift
@@ -10,16 +10,13 @@ import Dispatch
 
 /// A deferred is a value that may become determined (or "filled") at some point
 /// in the future. Once a deferred value is determined, it cannot change.
-public final class Deferred<Value>: FutureProtocol, PromiseProtocol {
+public struct Deferred<Value>: FutureProtocol, PromiseProtocol {
     /// The primary storage, initialized with a value once-and-only-once (at
     /// init or later).
     private let variant: Variant
-    // A semaphore that keeps efficiently keeps track of a callbacks list.
-    private let group = DispatchGroup()
 
     public init() {
         variant = Variant()
-        group.enter()
     }
 
     /// Creates an instance resolved with `value`.
@@ -27,37 +24,17 @@ public final class Deferred<Value>: FutureProtocol, PromiseProtocol {
         variant = Variant(for: value)
     }
 
-    deinit {
-        if !isFilled {
-            group.leave()
-        }
-    }
-
     // MARK: FutureProtocol
 
-    private func notify(flags: DispatchWorkItemFlags, upon queue: DispatchQueue, execute body: @escaping(Value) -> Void) {
-        group.notify(flags: flags, queue: queue) { [variant] in
-            guard let value = variant.load() else { return }
-            body(value)
-        }
-    }
-
-    public func upon(_ queue: DispatchQueue, execute body: @escaping (Value) -> Void) {
-        notify(flags: [ .assignCurrentContext, .inheritQoS ], upon: queue, execute: body)
+    /// An enqueued handler.
+    struct Continuation {
+        let target: Executor?
+        let handler: (Value) -> Void
     }
 
     public func upon(_ executor: Executor, execute body: @escaping(Value) -> Void) {
-        if let queue = executor as? DispatchQueue {
-            return upon(queue, execute: body)
-        } else if let queue = executor.underlyingQueue {
-            return upon(queue, execute: body)
-        }
-
-        notify(flags: .assignCurrentContext, upon: .any()) { (value) in
-            executor.submit {
-                body(value)
-            }
-        }
+        let continuation = Continuation(target: executor, handler: body)
+        variant.notify(continuation)
     }
 
     public func peek() -> Value? {
@@ -65,20 +42,34 @@ public final class Deferred<Value>: FutureProtocol, PromiseProtocol {
     }
 
     public func wait(until time: DispatchTime) -> Value? {
-        guard case .success = group.wait(timeout: time) else { return nil }
-        return peek()
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Value?
+
+        let continuation = Continuation(target: nil) { (value) in
+            result = value
+            semaphore.signal()
+        }
+
+        variant.notify(continuation)
+
+        guard case .success = semaphore.wait(timeout: time) else { return nil }
+        return result
     }
 
     // MARK: PromiseProtocol
 
     @discardableResult
     public func fill(with value: Value) -> Bool {
-        let wonRace = variant.store(value)
+        return variant.store(value)
+    }
+}
 
-        if wonRace {
-            group.leave()
-        }
-
-        return wonRace
+extension Deferred.Continuation {
+    /// A continuation can be submitted to its passed-in executor or executed
+    /// in the current context.
+    func execute(with value: Value) {
+        target?.submit {
+            self.handler(value)
+        } ?? handler(value)
     }
 }

--- a/Sources/Deferred/Deferred.swift
+++ b/Sources/Deferred/Deferred.swift
@@ -10,7 +10,7 @@ import Dispatch
 
 /// A deferred is a value that may become determined (or "filled") at some point
 /// in the future. Once a deferred value is determined, it cannot change.
-public struct Deferred<Value>: FutureProtocol, PromiseProtocol {
+public struct Deferred<Value> {
     /// The primary storage, initialized with a value once-and-only-once (at
     /// init or later).
     private let variant: Variant
@@ -23,9 +23,9 @@ public struct Deferred<Value>: FutureProtocol, PromiseProtocol {
     public init(filledWith value: Value) {
         variant = Variant(for: value)
     }
+}
 
-    // MARK: FutureProtocol
-
+extension Deferred: FutureProtocol {
     /// An enqueued handler.
     struct Continuation {
         let target: Executor?
@@ -55,13 +55,6 @@ public struct Deferred<Value>: FutureProtocol, PromiseProtocol {
         guard case .success = semaphore.wait(timeout: time) else { return nil }
         return result
     }
-
-    // MARK: PromiseProtocol
-
-    @discardableResult
-    public func fill(with value: Value) -> Bool {
-        return variant.store(value)
-    }
 }
 
 extension Deferred.Continuation {
@@ -71,5 +64,12 @@ extension Deferred.Continuation {
         target?.submit {
             self.handler(value)
         } ?? handler(value)
+    }
+}
+
+extension Deferred: PromiseProtocol {
+    @discardableResult
+    public func fill(with value: Value) -> Bool {
+        return variant.store(value)
     }
 }

--- a/Sources/Deferred/DeferredQueue.swift
+++ b/Sources/Deferred/DeferredQueue.swift
@@ -1,0 +1,94 @@
+//
+//  DeferredQueue.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 2/22/18.
+//  Copyright © 2018 Big Nerd Ranch. Licensed under MIT.
+//
+
+#if SWIFT_PACKAGE || COCOAPODS
+import Atomics
+#endif
+
+extension Deferred {
+    /// Heap storage acting as a linked list node of continuations.
+    ///
+    /// The use of `ManagedBuffer` ensures aligned and heap-allocated addresses
+    /// for the storage. The storage is tail-allocated with a reference to the
+    /// next node.
+    final class Node: ManagedBuffer<AnyObject?, Continuation> {
+        fileprivate static func create(with continuation: Continuation) -> Node {
+            let storage = super.create(minimumCapacity: 1, makingHeaderWith: { _ in nil })
+
+            storage.withUnsafeMutablePointers { (_, pointerToContinuation) in
+                pointerToContinuation.initialize(to: continuation)
+            }
+
+            return unsafeDowncast(storage, to: Node.self)
+        }
+
+        deinit {
+            _ = withUnsafeMutablePointers { (_, pointerToContinuation) in
+                pointerToContinuation.deinitialize(count: 1)
+            }
+        }
+    }
+
+    /// A singly-linked list of continuations to be submitted after fill.
+    ///
+    /// A multi-producer, single-consumer atomic queue a la `DispatchGroup`:
+    /// <https://github.com/apple/swift-corelibs-libdispatch/blob/master/src/semaphore.c>.
+    struct Queue {
+        fileprivate(set) var head: Node?
+        fileprivate(set) var tail: Node?
+    }
+}
+
+private extension Deferred.Node {
+    /// The next node in the linked list.
+    ///
+    /// - warning: To alleviate data races, the next node is loaded
+    ///   unconditionally. `self` must have been checked not to be the tail.
+    var next: Deferred.Node {
+        get {
+            return withUnsafeMutablePointers { (target, _) in
+                unsafeDowncast(bnr_atomic_load_and_wait(target), to: Deferred.Node.self)
+            }
+        }
+        set {
+            _ = withUnsafeMutablePointers { (target, _) in
+                bnr_atomic_store(target, newValue, .relaxed)
+            }
+        }
+    }
+
+    func execute(with value: Value) {
+        withUnsafeMutablePointers { (_, pointerToContinuation) in
+            pointerToContinuation.pointee.execute(with: value)
+        }
+    }
+}
+
+extension Deferred {
+    static func drain(from target: UnsafeMutablePointer<Queue>, continuingWith value: Value) {
+        var head = bnr_atomic_store(&target.pointee.head, nil, .relaxed)
+        let tail = head != nil ? bnr_atomic_store(&target.pointee.tail, nil, .release) : nil
+
+        while let current = head {
+            head = current !== tail ? current.next : nil
+            current.execute(with: value)
+        }
+    }
+
+    static func push(_ continuation: Continuation, to target: UnsafeMutablePointer<Queue>) -> Bool {
+        let node = Node.create(with: continuation)
+
+        if let tail = bnr_atomic_store(&target.pointee.tail, node, .release) {
+            tail.next = node
+            return false
+        }
+
+        _ = bnr_atomic_store(&target.pointee.head, node, .seq_cst)
+        return true
+    }
+}

--- a/Sources/Deferred/DeferredVariant.swift
+++ b/Sources/Deferred/DeferredVariant.swift
@@ -1,0 +1,113 @@
+//
+//  DeferredVariant.swift
+//  Deferred
+//
+//  Created by Zachary Waldowski on 2/22/18.
+//  Copyright © 2018 Big Nerd Ranch. Licensed under MIT.
+//
+
+#if SWIFT_PACKAGE || COCOAPODS
+import Atomics
+#endif
+
+extension Deferred {
+    /// Deferred's storage. It, lock-free but thread-safe, can be initialized
+    /// with a value once and only once.
+    ///
+    /// An underlying implementation is chosen at init. The variants that start
+    /// unfilled use `ManagedBuffer` to guarantee aligned and heap-allocated
+    /// addresses for atomic access.
+    ///
+    /// - note: **Q:** Why not just stored properties? Aren't you overthinking
+    ///   it? **A:** We want raw memory because Swift reserves the right to
+    ///   lay out properties opaquely. To that end, the initial store done
+    ///   during `init` counts as unsafe access to TSAN.
+    enum Variant {
+        case object(ObjectVariant)
+        case native(NativeVariant)
+        indirect case filled(Value)
+    }
+
+    /// Heap storage that is initialized once and only once from `nil` to a
+    /// reference. See `Deferred.Variant` for more details.
+    final class ObjectVariant: ManagedBuffer<Void, AnyObject?> {
+        fileprivate static func create() -> ObjectVariant {
+            let storage = super.create(minimumCapacity: 1, makingHeaderWith: { _ in })
+
+            storage.withUnsafeMutablePointers { (_, pointerToValue) in
+                bnr_atomic_init(pointerToValue)
+            }
+
+            return unsafeDowncast(storage, to: ObjectVariant.self)
+        }
+
+        deinit {
+            withUnsafeMutablePointers { (_, pointerToValue) in
+                _ = pointerToValue.deinitialize(count: 1)
+            }
+        }
+    }
+
+    /// Heap storage that is initialized once and only once using a flag.
+    /// See `Deferred.Variant` for more details.
+    final class NativeVariant: ManagedBuffer<Bool, Value> {
+        fileprivate static func create() -> NativeVariant {
+            let storage = super.create(minimumCapacity: 1, makingHeaderWith: { _ in false })
+            return unsafeDowncast(storage, to: NativeVariant.self)
+        }
+
+        deinit {
+            withUnsafeMutablePointers { (pointerToHeader, pointerToValue) in
+                if pointerToHeader.pointee {
+                    pointerToValue.deinitialize(count: 1)
+                }
+            }
+        }
+    }
+}
+
+extension Deferred.Variant {
+    init() {
+        if Value.self is AnyObject.Type {
+            self = .object(.create())
+        } else {
+            self = .native(.create())
+        }
+    }
+
+    init(for value: Value) {
+        self = .filled(value)
+    }
+
+    func load() -> Value? {
+        switch self {
+        case .object(let storage):
+            return storage.withUnsafeMutablePointers { (_, pointerToValue) in
+                unsafeBitCast(bnr_atomic_load(pointerToValue, .relaxed), to: Value?.self)
+            }
+        case .native(let storage):
+            return storage.withUnsafeMutablePointers { (pointerToHeader, pointerToValue) in
+                bnr_atomic_load(pointerToHeader, .relaxed) ? pointerToValue.pointee : nil
+            }
+        case .filled(let value):
+            return value
+        }
+    }
+
+    func store(_ value: Value) -> Bool {
+        switch self {
+        case .object(let storage):
+            return storage.withUnsafeMutablePointers { (_, pointerToValue) in
+                bnr_atomic_initialize_once(pointerToValue, unsafeBitCast(value, to: AnyObject.self))
+            }
+        case .native(let storage):
+            return storage.withUnsafeMutablePointers { (pointerToHeader, pointerToValue) in
+                bnr_atomic_initialize_once(pointerToHeader) {
+                    pointerToValue.initialize(to: value)
+                }
+            }
+        case .filled:
+            return false
+        }
+    }
+}

--- a/Sources/Deferred/Executor.swift
+++ b/Sources/Deferred/Executor.swift
@@ -49,21 +49,12 @@ public protocol Executor: class {
 
     /// Execute the `workItem`.
     func submit(_ workItem: DispatchWorkItem)
-
-    /// If the executor is a higher-level wrapper around a dispatch queue,
-    /// may be used instead of `submit(_:)` for more efficient execution.
-    var underlyingQueue: DispatchQueue? { get }
 }
 
 extension Executor {
     /// By default, submits the closure contents of the work item.
     public func submit(_ workItem: DispatchWorkItem) {
         submit(workItem.perform)
-    }
-
-    /// By default, `nil`; the executor's `submit(_:)` is used unconditionally.
-    public var underlyingQueue: DispatchQueue? {
-        return nil
     }
 }
 
@@ -94,10 +85,6 @@ extension DispatchQueue: Executor {
 
     public func submit(_ workItem: DispatchWorkItem) {
         async(execute: workItem)
-    }
-
-    public var underlyingQueue: DispatchQueue? {
-        return self
     }
 }
 

--- a/Sources/Deferred/Future.swift
+++ b/Sources/Deferred/Future.swift
@@ -30,9 +30,6 @@ public protocol FutureProtocol: CustomDebugStringConvertible, CustomReflectable 
     /// A type that represents the result of some asynchronous operation.
     associatedtype Value
 
-    /// Calls some `body` closure once the value is determined.
-    func upon(_ executor: PreferredExecutor, execute body: @escaping(Value) -> Void)
-
     /// Call some `body` closure once the value is determined.
     ///
     /// If the value is determined, the closure should be submitted to the

--- a/Tests/DeferredTests/FutureTests.swift
+++ b/Tests/DeferredTests/FutureTests.swift
@@ -107,10 +107,10 @@ class FutureTests: XCTestCase {
 
     func testEveryMapTransformerIsCalledMultipleTimes() {
         let deferred = Deferred(filledWith: 1)
-        var counter = bnr_atomic_counter()
+        var counter = 0
 
         let mapped = deferred.every { (value) -> (Int) in
-            bnr_atomic_counter_increment(&counter)
+            bnr_atomic_fetch_add(&counter, 1)
             return value * 2
         }
 
@@ -122,6 +122,6 @@ class FutureTests: XCTestCase {
         shortWait(for: [ expect ])
 
         XCTAssertEqual(mapped.value, 2)
-        XCTAssertEqual(bnr_atomic_counter_load(&counter), 2)
+        XCTAssertEqual(bnr_atomic_load(&counter), 2)
     }
 }


### PR DESCRIPTION
`Deferred` is meant to handle large parts of an app's asynchronous control flow, so its performance is critical. We've strived in the past to use the best constructs we have at our disposal to make this possible, like being early adopters of GCD in Swift. #213 revealed we can still do better! 😃

### What's in this pull request?

By combining our waiters queue and the storage, `Deferred` (the type) can reach same-ballpark performance as GCD while maintaining the same invariants.

Per the performance tests, this PR features:

- A 70% reduction in peak memory usage
- A 35% speed improvement in simple operations
- An 80% speed improvement in chained operations
- Smaller call stacks when debugging `upon` handlers.

In summary: same great taste, less filling.

This representation allows Swift-side access to handlers, possibly allowing for #203.

#### TODO

- [x] What about code size? This PR gains about 30KB for Release under 4.1, which is livable, but not ideal for my OCD.

### Testing

Largely no impact, but `Deferred` gains a specialization `where Value: AnyObject` that needs testing.

#### TODO

- [x] Needs duplicated tests to handle `AnyObject` specialization
- [x] Double-check other coverage implications

### API Changes

No public API changes here, it's all under the hood.