### PR TITLE
Replace bare inits on Future and Task with `.never`

### DIFF
--- a/Sources/Deferred/ExistentialFuture.swift
+++ b/Sources/Deferred/ExistentialFuture.swift
@@ -3,7 +3,7 @@
 //  Deferred
 //
 //  Created by Zachary Waldowski on 8/29/15.
-//  Copyright © 2014-2016 Big Nerd Ranch. Licensed under MIT.
+//  Copyright © 2014-2018 Big Nerd Ranch. Licensed under MIT.
 //
 
 import Dispatch
@@ -134,9 +134,13 @@ public struct Future<Value>: FutureProtocol {
         self.box = Always(value: value)
     }
 
-    /// Create a future that will never get fulfilled.
-    public init() {
+    private init(never: ()) {
         self.box = Never()
+    }
+
+    /// Create a future that will never get fulfilled.
+    public static var never: Future<Value> {
+        return Future(never: ())
     }
 
     /// Create a future having the same underlying future as `other`.

--- a/Sources/Task/ExistentialTask.swift
+++ b/Sources/Task/ExistentialTask.swift
@@ -42,9 +42,8 @@ public final class Task<SuccessValue>: NSObject {
         self.progress = .taskRoot(for: progress)
     }
 
-    /// Create a task that will never complete.
-    public override init() {
-        self.future = Future()
+    private init(never: ()) {
+        self.future = .never
         self.progress = .indefinite()
     }
 
@@ -81,12 +80,16 @@ public final class Task<SuccessValue>: NSObject {
         self.cancellation = cancellation ?? {}
     }
 
-    /// Create a task that will never complete.
-    public override init() {
-        self.future = Future()
+    private init(never: ()) {
+        self.future = .never
         self.cancellation = {}
     }
     #endif
+
+    /// Create a task that will never complete.
+    public static var never: Task<SuccessValue> {
+        return Task(never: ())
+    }
 }
 
 extension Task: FutureProtocol {

--- a/Tests/DeferredTests/ExistentialFutureTests.swift
+++ b/Tests/DeferredTests/ExistentialFutureTests.swift
@@ -41,7 +41,7 @@ class ExistentialFutureTests: XCTestCase {
     }
 
     func testPeekWhenUnfilled() {
-        anyFuture = Future<Int>()
+        anyFuture = Future<Int>.never
         let peek = anyFuture.peek()
         XCTAssertNil(peek)
     }
@@ -103,7 +103,7 @@ class ExistentialFutureTests: XCTestCase {
     }
 
     func testDebugDescriptionUnfilled() {
-        let future = Future<Int>()
+        let future = Future<Int>.never
         XCTAssertEqual("\(future)", "Future(not filled)")
     }
 
@@ -118,7 +118,7 @@ class ExistentialFutureTests: XCTestCase {
     }
 
     func testReflectionUnfilled() {
-        let future = Future<Int>()
+        let future = Future<Int>.never
 
         let magicMirror = Mirror(reflecting: future)
         XCTAssertEqual(magicMirror.displayStyle, .optional)

--- a/Tests/TaskTests/TaskTests.swift
+++ b/Tests/TaskTests/TaskTests.swift
@@ -117,7 +117,7 @@ class TaskTests: CustomExecutorTestCase {
     func testThatAndThenForwardsCancellationToSubsequentTask() {
         let expect = expectation(description: "flatMapped task is cancelled")
         let task = makeAnyFinishedTask().andThen(upon: executor) { _ -> Task<String> in
-            Task(future: Future()) { expect.fulfill() }
+            Task(future: .never) { expect.fulfill() }
         }
 
         task.cancel()
@@ -227,7 +227,7 @@ class TaskTests: CustomExecutorTestCase {
     }
 
     func testThatTaskCreatedUnfilledIsIndeterminate() {
-        let task = Task<Int>()
+        let task = Task<Int>.never
 
         XCTAssert(task.progress.isIndeterminate)
     }


### PR DESCRIPTION
#### What's in this pull request?

Working towards #221 by moving the appropriate bare `init()`s out to static `.never` getters.

#### Testing

N/A, just renames.

#### API Changes

Renames.