### PR TITLE
Audit naming of all convenience initializers to Task

### DIFF
--- a/Sources/Deferred/ExistentialFuture.swift
+++ b/Sources/Deferred/ExistentialFuture.swift
@@ -104,12 +104,11 @@ public struct Future<Value>: FutureProtocol {
     private let box: Box<Value>
 
     /// Create a future whose `upon(_:execute:)` methods forward to `base`.
-    public init<OtherFuture: FutureProtocol>(_ base: OtherFuture)
-        where OtherFuture.Value == Value {
-        if let future = base as? Future<Value> {
+    public init<Wrapped: FutureProtocol>(_ wrapped: Wrapped) where Wrapped.Value == Value {
+        if let future = wrapped as? Future<Value> {
             self.box = future.box
         } else {
-            self.box = ForwardedTo(base: base)
+            self.box = ForwardedTo(base: wrapped)
         }
     }
 
@@ -128,8 +127,8 @@ public struct Future<Value>: FutureProtocol {
     }
 
     /// Create a future having the same underlying future as `other`.
-    public init(_ other: Future<Value>) {
-        self.box = other.box
+    public init(_ future: Future<Value>) {
+        self.box = future.box
     }
 
     public func upon(_ executor: Executor, execute body: @escaping(Value) -> Void) {

--- a/Sources/Deferred/Promise.swift
+++ b/Sources/Deferred/Promise.swift
@@ -64,7 +64,7 @@ extension PromiseProtocol where Value == Void {
     /// Filling a deferred event should usually be attempted only once.
     ///
     /// - returns: Whether the promise was fulfilled.
-    @discardableResult @available(swift 4)
+    @discardableResult
     func fill() -> Bool {
         return fill(with: ())
     }

--- a/Sources/Task/ExistentialTask.swift
+++ b/Sources/Task/ExistentialTask.swift
@@ -43,7 +43,7 @@ public final class Task<SuccessValue>: NSObject {
     public let progress: Progress
 
     /// Creates a task given a `future` and its `progress`.
-    public init(future: Future<Result>, progress: Progress) {
+    public init(_ future: Future<Result>, progress: Progress) {
         self.future = future
         self.progress = .taskRoot(for: progress)
     }
@@ -57,21 +57,21 @@ public final class Task<SuccessValue>: NSObject {
     ///
     /// `cancellation` will be called asynchronously, but not on any specific
     /// queue. If you must do work on a specific queue, schedule work on it.
-    public convenience init(future base: Future<Result>, cancellation: (() -> Void)? = nil) {
-        let progress = Progress.wrappingSuccess(of: base, cancellation: cancellation)
-        self.init(future: base, progress: progress)
+    public convenience init(_ future: Future<Result>, uponCancel cancellation: (() -> Void)? = nil) {
+        let progress = Progress.wrappingSuccess(of: future, uponCancel: cancellation)
+        self.init(future, progress: progress)
     }
 
     /// Creates a task whose `upon(_:execute:)` methods use those of `base`.
-    public convenience init<OtherTask: TaskProtocol>(_ base: OtherTask, progress: Progress) where OtherTask.SuccessValue == SuccessValue {
-        let future = Future<Result>(task: base)
-        self.init(future: future, progress: progress)
+    public convenience init<Wrapped: TaskProtocol>(_ wrapped: Wrapped, progress: Progress) where Wrapped.SuccessValue == SuccessValue {
+        let future = Future<Result>(wrapped)
+        self.init(future, progress: progress)
     }
 
     /// Creates a task whose `upon(_:execute:)` methods use those of `base`.
-    public convenience init<OtherFuture: FutureProtocol>(success base: OtherFuture, progress: Progress) where OtherFuture.Value == SuccessValue {
-        let future = Future<Result>(success: base)
-        self.init(future: future, progress: progress)
+    public convenience init<Wrapped: FutureProtocol>(succeedsFrom wrapped: Wrapped, progress: Progress) where Wrapped.Value == SuccessValue {
+        let future = Future<Result>(succeedsFrom: wrapped)
+        self.init(future, progress: progress)
     }
     #else
     private let cancellation: () -> Void
@@ -81,7 +81,7 @@ public final class Task<SuccessValue>: NSObject {
     ///
     /// `cancellation` will be called asynchronously, but not on any specific
     /// queue. If you must do work on a specific queue, schedule work on it.
-    public init(future: Future<Result>, cancellation: (() -> Void)? = nil) {
+    public init(_ future: Future<Result>, uponCancel cancellation: (() -> Void)? = nil) {
         self.future = future
         self.cancellation = cancellation ?? {}
     }
@@ -143,18 +143,18 @@ extension Task {
     ///
     /// `cancellation` will be called asynchronously, but not on any specific
     /// queue. If you must do work on a specific queue, schedule work on it.
-    public convenience init<OtherTask: TaskProtocol>(_ base: OtherTask, cancellation: (() -> Void)? = nil) where OtherTask.SuccessValue == SuccessValue {
-        let future = Future<Result>(task: base)
+    public convenience init<Wrapped: TaskProtocol>(_ wrapped: Wrapped, uponCancel cancellation: (() -> Void)? = nil) where Wrapped.SuccessValue == SuccessValue {
+        let future = Future<Result>(wrapped)
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-        let progress = Progress.wrappingSuccess(of: base, cancellation: cancellation)
-        self.init(future: future, progress: progress)
+        let progress = Progress.wrappingSuccess(of: wrapped, uponCancel: cancellation)
+        self.init(future, progress: progress)
         #else
-        self.init(future: future) {
-            base.cancel()
+        self.init(future) {
+            wrapped.cancel()
             cancellation?()
         }
 
-        if base.isCancelled {
+        if wrapped.isCancelled {
             markCancelled(using: cancellation)
         }
         #endif
@@ -164,13 +164,13 @@ extension Task {
     ///
     /// `cancellation` will be called asynchronously, but not on any specific
     /// queue. If you must do work on a specific queue, schedule work on it.
-    public convenience init<OtherFuture: FutureProtocol>(success base: OtherFuture, cancellation: (() -> Void)? = nil) where OtherFuture.Value == SuccessValue {
-        let future = Future<Result>(success: base)
+    public convenience init<Wrapped: FutureProtocol>(succeedsFrom wrapped: Wrapped, uponCancel cancellation: (() -> Void)? = nil) where Wrapped.Value == SuccessValue {
+        let future = Future<Result>(succeedsFrom: wrapped)
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-        let progress = Progress.wrappingCompletion(of: base, cancellation: cancellation)
-        self.init(future: future, progress: progress)
+        let progress = Progress.wrappingCompletion(of: wrapped, uponCancel: cancellation)
+        self.init(future, progress: progress)
         #else
-        self.init(future: future)
+        self.init(future, uponCancel: cancellation)
         #endif
     }
 
@@ -178,9 +178,9 @@ extension Task {
     public convenience init(success value: @autoclosure() throws -> SuccessValue) {
         let future = Future<Result>(value: Result(from: value))
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-        self.init(future: future, progress: .noWork())
+        self.init(future, progress: .noWork())
 #else
-        self.init(future: future, cancellation: nil)
+        self.init(future)
 #endif
     }
 
@@ -188,19 +188,19 @@ extension Task {
     public convenience init(failure error: Error) {
         let future = Future<Result>(value: Result(failure: error))
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-        self.init(future: future, progress: .noWork())
+        self.init(future, progress: .noWork())
 #else
-        self.init(future: future, cancellation: nil)
+        self.init(future)
 #endif
     }
 
     /// Creates a task having the same underlying operation as the `other` task.
-    public convenience init(_ other: Task<SuccessValue>) {
+    public convenience init(_ task: Task<SuccessValue>) {
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-        self.init(future: other.future, progress: other.progress)
+        self.init(task.future, progress: task.progress)
 #else
-        self.init(future: other.future, cancellation: other.cancellation)
-        if other.isCancelled {
+        self.init(task.future, uponCancel: task.cancellation)
+        if task.isCancelled {
             markCancelled()
         }
 #endif

--- a/Sources/Task/ExistentialTask.swift
+++ b/Sources/Task/ExistentialTask.swift
@@ -176,7 +176,7 @@ extension Task {
 
     /// Creates an operation that has already completed with `value`.
     public convenience init(success value: @autoclosure() throws -> SuccessValue) {
-        let future = Future<Result>(value: Result(from: value))
+        let future = Future<Result>(success: value)
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         self.init(future, progress: .noWork())
 #else
@@ -186,7 +186,7 @@ extension Task {
 
     /// Creates an operation that has already failed with `error`.
     public convenience init(failure error: Error) {
-        let future = Future<Result>(value: Result(failure: error))
+        let future = Future<Result>(failure: error)
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         self.init(future, progress: .noWork())
 #else

--- a/Sources/Task/Task.swift
+++ b/Sources/Task/Task.swift
@@ -83,15 +83,15 @@ extension Future: TaskProtocol where Value: Either, Value.Left == Error {
     public typealias SuccessValue = Value.Right
 
     /// Create a future having the same underlying task as `other`.
-    public init<OtherTask: TaskProtocol>(task other: OtherTask) where OtherTask.SuccessValue == SuccessValue, OtherTask.FailureValue == FailureValue {
-        self = other as? Future<Value> ?? other.every {
+    public init<Wrapped: TaskProtocol>(_ wrapped: Wrapped) where Wrapped.SuccessValue == SuccessValue, Wrapped.FailureValue == FailureValue {
+        self = wrapped as? Future<Value> ?? wrapped.every {
             $0.withValues(ifLeft: Value.init(left:), ifRight: Value.init(right:))
         }
     }
 
     /// Create a future having the same underlying task as `other`.
-    public init<OtherFuture: FutureProtocol>(success other: OtherFuture) where OtherFuture.Value == SuccessValue {
-        self = other.every(per: Value.init(right:))
+    public init<Wrapped: FutureProtocol>(succeedsFrom wrapped: Wrapped) where Wrapped.Value == SuccessValue {
+        self = wrapped.every(per: Value.init(right:))
     }
 }
 

--- a/Sources/Task/Task.swift
+++ b/Sources/Task/Task.swift
@@ -93,6 +93,16 @@ extension Future: TaskProtocol where Value: Either, Value.Left == Error {
     public init<Wrapped: FutureProtocol>(succeedsFrom wrapped: Wrapped) where Wrapped.Value == SuccessValue {
         self = wrapped.every(per: Value.init(right:))
     }
+
+    /// Creates an future having already filled successfully with `value`.
+    public init(success value: @autoclosure() throws -> SuccessValue) {
+        self.init(value: Value(from: value))
+    }
+
+    /// Creates an future having already failed with `error`.
+    public init(failure error: FailureValue) {
+        self.init(value: Value(left: error))
+    }
 }
 
 extension Deferred: TaskProtocol where Value: Either, Value.Left == Error {

--- a/Sources/Task/TaskAndThen.swift
+++ b/Sources/Task/TaskAndThen.swift
@@ -69,9 +69,9 @@ extension TaskProtocol {
         }
 
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-        return Task<NewTask.SuccessValue>(future: future, progress: progress)
+        return Task<NewTask.SuccessValue>(future, progress: progress)
         #else
-        return Task<NewTask.SuccessValue>(future: future) {
+        return Task<NewTask.SuccessValue>(future) {
             cancellationToken.fill(with: ())
         }
         #endif

--- a/Sources/Task/TaskCollections.swift
+++ b/Sources/Task/TaskCollections.swift
@@ -39,7 +39,7 @@ private struct AllFilled<SuccessValue>: TaskProtocol {
             if let task = future as? Task<Base.Element.SuccessValue> {
                 progress.adoptChild(task.progress, orphaned: false, pendingUnitCount: 1)
             } else {
-                progress.adoptChild(.wrappingSuccess(of: future, cancellation: nil), orphaned: true, pendingUnitCount: 1)
+                progress.adoptChild(.wrappingSuccess(of: future), orphaned: true, pendingUnitCount: 1)
             }
             #endif
 
@@ -99,7 +99,7 @@ extension Collection where Element: TaskProtocol {
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         return Task(wrapper, progress: wrapper.progress)
         #else
-        return Task(wrapper, cancellation: wrapper.cancel)
+        return Task(wrapper, uponCancel: wrapper.cancel)
         #endif
     }
 }
@@ -120,7 +120,7 @@ extension Collection where Element: TaskProtocol, Element.SuccessValue == Void {
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         return Task(wrapper, progress: wrapper.progress)
         #else
-        return Task(wrapper, cancellation: wrapper.cancel)
+        return Task(wrapper, uponCancel: wrapper.cancel)
         #endif
     }
 }

--- a/Sources/Task/TaskFallback.swift
+++ b/Sources/Task/TaskFallback.swift
@@ -57,9 +57,9 @@ extension TaskProtocol {
         }
 
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-        return Task<SuccessValue>(future: future, progress: progress)
+        return Task<SuccessValue>(future, progress: progress)
         #else
-        return Task<SuccessValue>(future: future, cancellation: cancel)
+        return Task<SuccessValue>(future, uponCancel: cancel)
         #endif
     }
 }

--- a/Sources/Task/TaskIgnore.swift
+++ b/Sources/Task/TaskIgnore.swift
@@ -29,10 +29,10 @@ extension TaskProtocol {
 
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         if let progress = (self as? Task<SuccessValue>)?.progress {
-            return Task<Void>(future: future, progress: progress)
+            return Task<Void>(future, progress: progress)
         }
         #endif
 
-        return Task<Void>(future: future, cancellation: cancel)
+        return Task<Void>(future, uponCancel: cancel)
     }
 }

--- a/Sources/Task/TaskMap.swift
+++ b/Sources/Task/TaskMap.swift
@@ -50,9 +50,9 @@ extension TaskProtocol {
         }
 
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-        return Task<NewSuccessValue>(future: future, progress: progress)
+        return Task<NewSuccessValue>(future, progress: progress)
         #else
-        return Task<NewSuccessValue>(future: future, cancellation: cancel)
+        return Task<NewSuccessValue>(future, uponCancel: cancel)
         #endif
     }
 }

--- a/Sources/Task/TaskProgress.swift
+++ b/Sources/Task/TaskProgress.swift
@@ -207,7 +207,7 @@ extension Progress {
 
     /// A simple indeterminate progress with a cancellation function.
     static func wrappingCompletion<OtherFuture: FutureProtocol>(of base: OtherFuture, cancellation: (() -> Void)?) -> Progress {
-        let totalUnitCount: Int64 = base.wait(until: .now()) != nil ? 0 : -1
+        let totalUnitCount: Int64 = base.peek() != nil ? 0 : -1
         let progress = Progress(totalUnitCount: totalUnitCount)
 
         if let cancellation = cancellation {

--- a/Sources/Task/TaskPromise.swift
+++ b/Sources/Task/TaskPromise.swift
@@ -40,7 +40,7 @@ extension TaskProtocol where Self: PromiseProtocol, SuccessValue == Void {
     ///
     /// - seealso: `PromiseProtocol.fill(with:)`
     /// - seealso: `TaskProtocol.succeed(with:)`
-    @discardableResult @available(swift 4)
+    @discardableResult
     public func succeed() -> Bool {
         return fill(with: Value(right: ()))
     }

--- a/Sources/Task/TaskRecovery.swift
+++ b/Sources/Task/TaskRecovery.swift
@@ -52,9 +52,9 @@ extension TaskProtocol {
         }
 
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-        return Task<SuccessValue>(future: future, progress: progress)
+        return Task<SuccessValue>(future, progress: progress)
         #else
-        return Task<SuccessValue>(future: future, cancellation: cancel)
+        return Task<SuccessValue>(future, uponCancel: cancel)
         #endif
     }
 }

--- a/Sources/Task/TaskResult.swift
+++ b/Sources/Task/TaskResult.swift
@@ -51,7 +51,6 @@ private enum TaskResultInitializerError: Error {
 
 extension TaskResult where Value == Void {
     /// Creates the success value.
-    @available(swift 4)
     @_inlineable
     public init() {
         self = .success(())

--- a/Tests/TaskTests/TaskComprehensiveTests.swift
+++ b/Tests/TaskTests/TaskComprehensiveTests.swift
@@ -101,7 +101,7 @@ private final class TaskProducer {
             deferred.fill(with: .success(()))
         }
 
-        return Task(future: Future(deferred), cancellation: {
+        return Task(deferred, uponCancel: {
             deferred.fill(with: .failure(TaskProducerError.userCancelled))
         })
     }
@@ -114,7 +114,7 @@ private final class TaskProducer {
             deferred.fill(with: .success((items)))
         }
 
-        return Task(future: Future(deferred), cancellation: {
+        return Task(deferred, uponCancel: {
             deferred.fill(with: .failure(TaskProducerError.userCancelled))
         })
     }

--- a/Tests/TaskTests/TaskTests.swift
+++ b/Tests/TaskTests/TaskTests.swift
@@ -82,7 +82,7 @@ class TaskTests: CustomExecutorTestCase {
 
     private func makeContrivedNextTask(for result: Int) -> Task<Int> {
         let deferred = Deferred<Task<Int>.Result>()
-        let task = Task(deferred, cancellation: nil)
+        let task = Task(deferred)
         afterShortDelay {
             deferred.succeed(with: result * 2)
         }
@@ -120,7 +120,7 @@ class TaskTests: CustomExecutorTestCase {
     func testThatAndThenForwardsCancellationToSubsequentTask() {
         let expect = expectation(description: "flatMapped task is cancelled")
         let task = makeAnyFinishedTask().andThen(upon: executor) { _ -> Task<String> in
-            Task(future: .never) { expect.fulfill() }
+            Task(.never) { expect.fulfill() }
         }
 
         task.cancel()
@@ -237,7 +237,7 @@ class TaskTests: CustomExecutorTestCase {
 
     func testThatTaskWrappingUnfilledIsIndeterminate() {
         let deferred = Deferred<Task<Int>.Result>()
-        let wrappedTask = Task(deferred, cancellation: {})
+        let wrappedTask = Task(deferred)
 
         XCTAssertFalse(wrappedTask.progress.isIndeterminate)
     }
@@ -326,7 +326,7 @@ class TaskTests: CustomExecutorTestCase {
     func testSimpleFutureCanBeUpgradedToTask() {
         let deferred = Deferred<Int>()
 
-        let task = Task<Int>(success: deferred, cancellation: nil)
+        let task = Task<Int>(succeedsFrom: deferred)
         let expect = expectation(that: task, succeedsWith: 42)
 
         deferred.fill(with: 42)


### PR DESCRIPTION
#### What's in this pull request?

Completes #249. A bunch of renames under the banner of consistency.

#### Testing

Test coverage should not change.

#### API Changes

No surface area removals, but a bundle of renames 