### PR TITLE
Backpedal on hoisting PreferredExecutor into FutureProtocol

### DIFF
--- a/Sources/Deferred/FutureUpon.swift
+++ b/Sources/Deferred/FutureUpon.swift
@@ -8,11 +8,11 @@
 
 import Dispatch
 
-extension FutureProtocol {
-    /// The natural executor for use with futures; a policy of the framework to
-    /// allow for shorthand syntax with `Future.upon(_:execute:)` and others.
-    public typealias PreferredExecutor = DispatchQueue
+/// The natural executor for use with Futures; a policy of the framework to
+/// allow for shorthand syntax with `Future.upon(_:execute:)` and others.
+public typealias PreferredExecutor = DispatchQueue
 
+extension FutureProtocol {
     /// The executor to use as a default argument to `upon` methods on `Future`.
     ///
     /// Don't provide a default parameter using this declaration unless doing


### PR DESCRIPTION
#### What's in this pull request?

Reverts a semi-accidental change from #216 that's an upgrade pain and provides no benefit. Deferred already has `Executor` as public name, so it makes more sense for `PreferredExecutor` to live in the sample place.

#### Testing

No changes.
<!-- Changes to test coverage, and whether or not the resulting tests pass on your machine. -->

#### API Changes

Should be non-breaking for most users, and closes the gap when upgrading Deferred 3.0 to 4.0.