### PR TITLE
Fix spacing in the documentation for FutureProtocol's default executor

### DIFF
--- a/Sources/Deferred/FutureUpon.swift
+++ b/Sources/Deferred/FutureUpon.swift
@@ -17,7 +17,7 @@ extension FutureProtocol {
     ///
     /// Don't provide a default parameter using this declaration unless doing
     /// so is unambiguous. For instance, `map` and `andThen` once had a default
-    /// executor, but users found it unclear wherethe  handlers executed.
+    /// executor, but users found it unclear where the handlers executed.
     public static var defaultUponExecutor: PreferredExecutor {
         return DispatchQueue.any()
     }


### PR DESCRIPTION
A space meandered over to the incorrect side of `the`. Put's it back in it's place.

#### What's in this pull request?
Moved a space

#### Testing
N/A

#### API Changes
None
