### PR TITLE
Replace Deferred's CAtomics with Apple's swift-atomics package

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-atomics",
+        "repositoryURL": "https://github.com/apple/swift-atomics.git",
+        "state": {
+          "branch": null,
+          "revision": "b97750eb1815973a377cb85ea2f6c62374a9995d",
+          "version": "0.0.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -18,20 +18,28 @@ let package = Package(
     products: [
         .library(name: "Deferred", targets: [ "Deferred", "Task" ])
     ],
+    dependencies: [
+       .package(
+         url: "https://github.com/apple/swift-atomics.git",
+         from: "0.0.1"
+       )
+     ],
     targets: [
         .target(
             name: "Deferred",
-            dependencies: [ "CAtomics" ]),
+            dependencies: [
+            .product(name: "Atomics", package: "swift-atomics")
+             ]),
         .testTarget(
             name: "DeferredTests",
             dependencies: [ "Deferred" ],
             exclude: [ "Tests/AllTestsCommon.swift" ]),
         .target(
             name: "Task",
-            dependencies: [ "Deferred", "CAtomics" ]),
+            dependencies: [ "Deferred", .product(name: "Atomics", package: "swift-atomics") ]),
         .testTarget(
             name: "TaskTests",
             dependencies: [ "Deferred", "Task" ],
             exclude: [ "Tests/AllTestsCommon.swift" ]),
-        .target(name: "CAtomics")
+//        .target(name: "Atomics")
     ])

--- a/Package.swift
+++ b/Package.swift
@@ -29,17 +29,16 @@ let package = Package(
             name: "Deferred",
             dependencies: [
             .product(name: "Atomics", package: "swift-atomics")
-             ]),
+            ]),
         .testTarget(
             name: "DeferredTests",
             dependencies: [ "Deferred" ],
             exclude: [ "Tests/AllTestsCommon.swift" ]),
         .target(
             name: "Task",
-            dependencies: [ "Deferred", .product(name: "Atomics", package: "swift-atomics") ]),
+            dependencies: ["Deferred",.product(name: "Atomics", package: "swift-atomics")]),
         .testTarget(
             name: "TaskTests",
             dependencies: [ "Deferred", "Task" ],
-            exclude: [ "Tests/AllTestsCommon.swift" ]),
-//        .target(name: "Atomics")
+            exclude: [ "Tests/AllTestsCommon.swift" ])
     ])

--- a/Package.swift
+++ b/Package.swift
@@ -18,20 +18,27 @@ let package = Package(
     products: [
         .library(name: "Deferred", targets: [ "Deferred", "Task" ])
     ],
+    dependencies: [
+       .package(
+         url: "https://github.com/apple/swift-atomics.git",
+         from: "0.0.1"
+       )
+     ],
     targets: [
         .target(
             name: "Deferred",
-            dependencies: [ "CAtomics" ]),
+            dependencies: [
+            .product(name: "Atomics", package: "swift-atomics")
+            ]),
         .testTarget(
             name: "DeferredTests",
             dependencies: [ "Deferred" ],
             exclude: [ "Tests/AllTestsCommon.swift" ]),
         .target(
             name: "Task",
-            dependencies: [ "Deferred", "CAtomics" ]),
+            dependencies: ["Deferred",.product(name: "Atomics", package: "swift-atomics")]),
         .testTarget(
             name: "TaskTests",
             dependencies: [ "Deferred", "Task" ],
-            exclude: [ "Tests/AllTestsCommon.swift" ]),
-        .target(name: "CAtomics")
+            exclude: [ "Tests/AllTestsCommon.swift" ])
     ])


### PR DESCRIPTION
Change Deferred Swift package to use swift-atomic dependency:  https://github.com/apple/swift-atomics.git


#### What's in this pull request?
This change makes Deferred compatible with Xcode 12 when used as a Swift package.

After encountering the dreaded 'compiled with X.X version of Swift Compiler' message with the carthage frameworks, I decided to try Swift Package Manager. Deferred was already defined as a Swift Package, so I updated the version of swift atomic and got it testing & building.


#### Testing
No changes. Tests run

#### API Changes
No changes
